### PR TITLE
Add more options and hooks

### DIFF
--- a/src/ProtoInput/ProtoInputHooks/AdjustWindowRectHook.cpp
+++ b/src/ProtoInput/ProtoInputHooks/AdjustWindowRectHook.cpp
@@ -1,0 +1,59 @@
+#include "AdjustWindowRectHook.h"
+#include <imgui.h>
+
+namespace Proto
+{
+
+	int AdjustWindowRectHook::width = 0;
+	int AdjustWindowRectHook::height = 0;
+	int AdjustWindowRectHook::posx = 0;
+	int AdjustWindowRectHook::posy = 0;
+
+	RECT AdjustWindowRectHook::wr;
+
+	BOOL WINAPI Hook_AdjustWindowRect(LPRECT lpRect, DWORD dwStyle, BOOL bMenu)
+	{
+		lpRect->top = AdjustWindowRectHook::posy;
+		lpRect->left = AdjustWindowRectHook::posx;
+		lpRect->bottom = AdjustWindowRectHook::height + AdjustWindowRectHook::posy;
+		lpRect->right = AdjustWindowRectHook::width + AdjustWindowRectHook::posx;
+
+		return AdjustWindowRect(lpRect, dwStyle, false);;
+	}
+
+	BOOL WINAPI Hook_AdjustWindowRectEx(LPRECT lpRect, DWORD dwStyle, BOOL bMenu, DWORD dwExStyle)
+	{
+		lpRect->top = AdjustWindowRectHook::posy;
+		lpRect->left = AdjustWindowRectHook::posx;
+		lpRect->bottom = AdjustWindowRectHook::height + AdjustWindowRectHook::posy;
+		lpRect->right = AdjustWindowRectHook::width + AdjustWindowRectHook::posx;
+
+		return AdjustWindowRectEx(lpRect, dwStyle, false, dwExStyle);;
+	}
+
+	void AdjustWindowRectHook::ShowGuiStatus()
+	{
+		int pos[2] = { posx, posy };
+		ImGui::SliderInt2("Position", &pos[0], -5000, 5000);
+		posx = pos[0];
+		posy = pos[1];
+
+		int size[2] = { width, height };
+		ImGui::SliderInt2("Size", &size[0], 0, 5000);
+		width = size[0];
+		height = size[1];
+	}
+
+	void AdjustWindowRectHook::InstallImpl()
+	{
+		hookInfoRect = std::get<1>(InstallNamedHook(L"user32", "AdjustWindowRect", Hook_AdjustWindowRect));
+		hookInfoRectEx = std::get<1>(InstallNamedHook(L"user32", "AdjustWindowRectEx", Hook_AdjustWindowRectEx));
+	}
+
+	void AdjustWindowRectHook::UninstallImpl()
+	{
+		UninstallHook(&hookInfoRect);
+		UninstallHook(&hookInfoRectEx);
+	}
+
+}

--- a/src/ProtoInput/ProtoInputHooks/AdjustWindowRectHook.h
+++ b/src/ProtoInput/ProtoInputHooks/AdjustWindowRectHook.h
@@ -1,0 +1,34 @@
+#pragma once
+#include "Hook.h"
+#include "InstallHooks.h"
+
+namespace Proto
+{
+
+	class AdjustWindowRectHook final : public Hook
+	{
+	private:
+		HookInfo hookInfoRect{};
+		HookInfo hookInfoRectEx{};
+
+	public:
+		static int width;
+		static int height;
+		static int posx;
+		static int posy;
+
+		static RECT wr;
+
+		const char* GetHookName() const override { return "Adjust Window Rectangle"; }
+		const char* GetHookDescription() const override
+		{
+			return
+				"Hooks AdjustWindowRect and AdjustWindowRectEx. And calculates the required size of the window rectangle. ";
+		}
+		bool HasGuiStatus() const override { return false; }
+		void ShowGuiStatus() override;
+		void InstallImpl() override;
+		void UninstallImpl() override;
+	};
+
+}

--- a/src/ProtoInput/ProtoInputHooks/FakeMouseKeyboard.cpp
+++ b/src/ProtoInput/ProtoInputHooks/FakeMouseKeyboard.cpp
@@ -8,6 +8,8 @@ namespace Proto
 FakeMouseState FakeMouseKeyboard::mouseState{};
 FakeKeyboardState FakeMouseKeyboard::keyboardState{};
 
+bool FakeMouseKeyboard::PutMouseInsideWindow = false;
+
 void FakeMouseKeyboard::AddMouseDelta(int dx, int dy)
 {
 	mouseState.x += dx;
@@ -15,17 +17,39 @@ void FakeMouseKeyboard::AddMouseDelta(int dx, int dy)
 
 	if (!mouseState.ignoreMouseBounds)
 	{
-		int min = mouseState.extendMouseBounds ? -100 : -1;
-		if (mouseState.x < min)
-			mouseState.x = min;
-		if (mouseState.y < min)
-			mouseState.y = min;
+		if (!PutMouseInsideWindow)
+		{
+			int min = mouseState.extendMouseBounds ? -100 : -1;
+			if (mouseState.x < min)
+				mouseState.x = min;
+			if (mouseState.y < min)
+				mouseState.y = min;
+		}
+		else
+		{
+			int min = mouseState.extendMouseBounds ? -100 : 0;
+			if (mouseState.x < min)
+				mouseState.x = min;
+			if (mouseState.y < min)
+				mouseState.y = min;
+		}
 
-		if (int max = mouseState.extendMouseBounds ? HwndSelector::windowWidth + 100 : HwndSelector::windowWidth; mouseState.x > max)
-			mouseState.x = max;
+		if (!PutMouseInsideWindow)
+		{
+			if (int max = mouseState.extendMouseBounds ? HwndSelector::windowWidth + 100 : HwndSelector::windowWidth; mouseState.x > max)
+				mouseState.x = max;
 
-		if (int max = mouseState.extendMouseBounds ? HwndSelector::windowHeight + 100 : HwndSelector::windowHeight; mouseState.y > max)
-			mouseState.y = max;
+			if (int max = mouseState.extendMouseBounds ? HwndSelector::windowHeight + 100 : HwndSelector::windowHeight; mouseState.y > max)
+				mouseState.y = max;
+		}
+		else
+		{
+			if (int max = mouseState.extendMouseBounds ? HwndSelector::windowWidth + 1100 : HwndSelector::windowWidth; mouseState.x > max)
+				mouseState.x = max - 1;
+
+			if (int max = mouseState.extendMouseBounds ? HwndSelector::windowHeight + 700 : HwndSelector::windowHeight; mouseState.y > max)
+				mouseState.y = max - 1;
+		}
 		
 		if (mouseState.hasClipCursor)
 		{
@@ -50,17 +74,39 @@ void FakeMouseKeyboard::SetMousePos(int x, int y)
 
 	if (!mouseState.ignoreMouseBounds)
 	{
-		int min = mouseState.extendMouseBounds ? -100 : -1;
-		if (mouseState.x < min)
-			mouseState.x = min;
-		if (mouseState.y < min)
-			mouseState.y = min;
+		if (!PutMouseInsideWindow)
+		{
+			int min = mouseState.extendMouseBounds ? -100 : -1;
+			if (mouseState.x < min)
+				mouseState.x = min;
+			if (mouseState.y < min)
+				mouseState.y = min;
+		}
+		else
+		{
+			int min = mouseState.extendMouseBounds ? -100 : 0;
+			if (mouseState.x < min)
+				mouseState.x = min;
+			if (mouseState.y < min)
+				mouseState.y = min;
+		}
 
-		if (int max = mouseState.extendMouseBounds ? HwndSelector::windowWidth + 100 : HwndSelector::windowWidth; mouseState.x > max)
-			mouseState.x = max;
+		if (!PutMouseInsideWindow)
+		{
+			if (int max = mouseState.extendMouseBounds ? HwndSelector::windowWidth + 100 : HwndSelector::windowWidth; mouseState.x > max)
+				mouseState.x = max;
 
-		if (int max = mouseState.extendMouseBounds ? HwndSelector::windowHeight + 100 : HwndSelector::windowHeight; mouseState.y > max)
-			mouseState.y = max;
+			if (int max = mouseState.extendMouseBounds ? HwndSelector::windowHeight + 100 : HwndSelector::windowHeight; mouseState.y > max)
+				mouseState.y = max;
+		}
+		else
+		{
+			if (int max = mouseState.extendMouseBounds ? HwndSelector::windowWidth + 1100 : HwndSelector::windowWidth; mouseState.x > max)
+				mouseState.x = max - 1;
+
+			if (int max = mouseState.extendMouseBounds ? HwndSelector::windowHeight + 700 : HwndSelector::windowHeight; mouseState.y > max)
+				mouseState.y = max - 1;
+		}
 
 		if (mouseState.hasClipCursor)
 		{

--- a/src/ProtoInput/ProtoInputHooks/FakeMouseKeyboard.h
+++ b/src/ProtoInput/ProtoInputHooks/FakeMouseKeyboard.h
@@ -56,6 +56,9 @@ public:
 	static bool IsKeyStatePressed(int vkey);
 	static bool IsAsyncKeyStatePressed(int vkey);
 
+	// Some games must use the exact window rect to determine the edge of the window.
+	static bool PutMouseInsideWindow;
+
 	static unsigned int GetMouseMkFlags()
 	{
 #define PROTO_MMFKEY(x, y) ((FakeMouseKeyboard::IsKeyStatePressed(x)) ? (y) : (0))

--- a/src/ProtoInput/ProtoInputHooks/GetCursorPosHook.cpp
+++ b/src/ProtoInput/ProtoInputHooks/GetCursorPosHook.cpp
@@ -12,6 +12,20 @@ BOOL WINAPI Hook_GetCursorPos(LPPOINT lpPoint)
 		const auto& state = FakeMouseKeyboard::GetMouseState();
 		lpPoint->x = state.x;
 		lpPoint->y = state.y;
+
+		if (FakeMouseKeyboard::PutMouseInsideWindow)
+		{
+			int clientWidth = HwndSelector::windowWidth;
+			int clientHeight = HwndSelector::windowHeight;
+			if (lpPoint->y < 1)
+				lpPoint->y = 0;  // Top edge
+			if (lpPoint->x < 1)
+				lpPoint->x = 0;  // Left edge
+			if (lpPoint->y > clientHeight - 1)
+				lpPoint->y = clientHeight - 1;  // Bottom edge
+			if (lpPoint->x > clientWidth - 1)
+				lpPoint->x = clientWidth - 1;  // Right edge
+		}
 		ClientToScreen((HWND)HwndSelector::GetSelectedHwnd(), lpPoint);
 	}
 	

--- a/src/ProtoInput/ProtoInputHooks/Gui.cpp
+++ b/src/ProtoInput/ProtoInputHooks/Gui.cpp
@@ -207,6 +207,7 @@ void RawInputMenu()
     ImGui::Checkbox("Send mouse button messages", &RawInput::rawInputState.sendMouseButtonMessages);
     ImGui::Checkbox("Send mouse wheel messages", &RawInput::rawInputState.sendMouseWheelMessages);
     ImGui::Checkbox("Send keyboard button messages", &RawInput::rawInputState.sendKeyboardPressMessages);
+    ImGui::Checkbox("Send mouse double click messages", &RawInput::rawInputState.sendMouseDblClkMessages);
 
     ImGui::Separator();
 	

--- a/src/ProtoInput/ProtoInputHooks/HookManager.cpp
+++ b/src/ProtoInput/ProtoInputHooks/HookManager.cpp
@@ -18,6 +18,9 @@
 #include "FindWindowHook.h"
 #include "CreateSingleHIDHook.h"
 #include "WindowStyleHook.h"
+#include "MoveWindowHook.h"
+#include "AdjustWindowRectHook.h"
+#include "RemoveBorderHook.h"
 
 namespace Proto
 {
@@ -46,6 +49,9 @@ HookManager::HookManager()
 	AddHook<FindWindowHook>(ProtoHookIDs::FindWindowHookID);
 	AddHook<CreateSingleHIDHook>(ProtoHookIDs::CreateSingleHIDHookID);
 	AddHook<WindowStyleHook>(ProtoHookIDs::WindowStyleHookID);
+	AddHook<MoveWindowHook>(ProtoHookIDs::MoveWindowHookID);
+	AddHook<AdjustWindowRectHook>(ProtoHookIDs::AdjustWindowRectHookID);
+	AddHook<RemoveBorderHook>(ProtoHookIDs::RemoveBorderHookID);
 }
 
 void HookManager::InstallHook(ProtoHookIDs hookID)

--- a/src/ProtoInput/ProtoInputHooks/MouseButtonFilter.h
+++ b/src/ProtoInput/ProtoInputHooks/MouseButtonFilter.h
@@ -6,17 +6,17 @@
 namespace Proto
 {
 
-class MouseButtonFilter : public MessageFilterBase<ProtoMessageFilterIDs::MouseButtonFilterID, WM_LBUTTONDOWN, WM_XBUTTONUP>
+class MouseButtonFilter : public MessageFilterBase<ProtoMessageFilterIDs::MouseButtonFilterID, WM_LBUTTONDOWN, WM_XBUTTONDBLCLK>
 {
 public:
 	static constexpr unsigned int signature = 0x10000000;
 	
 	static bool Filter(unsigned int message, unsigned int* lparam, unsigned int* wparam, intptr_t hwnd)
 	{
-		if (message == WM_LBUTTONDOWN || message == WM_LBUTTONUP ||
-			message == WM_RBUTTONDOWN || message == WM_RBUTTONUP ||
-			message == WM_MBUTTONDOWN || message == WM_MBUTTONUP ||
-			message == WM_XBUTTONDOWN || message == WM_MBUTTONUP)
+		if (message == WM_LBUTTONDOWN || message == WM_LBUTTONUP || message == WM_LBUTTONDBLCLK ||
+			message == WM_RBUTTONDOWN || message == WM_RBUTTONUP || message == WM_RBUTTONDBLCLK ||
+			message == WM_MBUTTONDOWN || message == WM_MBUTTONUP || message == WM_MBUTTONDBLCLK ||
+			message == WM_XBUTTONDOWN || message == WM_MBUTTONUP || message == WM_XBUTTONDBLCLK)
 		{
 			if ((*wparam & signature) != 0)
 			{

--- a/src/ProtoInput/ProtoInputHooks/MoveWindowHook.cpp
+++ b/src/ProtoInput/ProtoInputHooks/MoveWindowHook.cpp
@@ -1,0 +1,48 @@
+#include "MoveWindowHook.h"
+#include <imgui.h>
+
+namespace Proto
+{
+
+	int MoveWindowHook::width = 0;
+	int MoveWindowHook::height = 0;
+	int MoveWindowHook::posx = 0;
+	int MoveWindowHook::posy = 0;
+
+	bool MoveWindowHook::MoveWindowDontResize = false;
+	bool MoveWindowHook::MoveWindowDontReposition = false;
+
+	BOOL WINAPI Hook_MoveWindow(HWND hWnd, int X, int Y, int nWidth, int nHeight, BOOL bRepaint)
+	{
+		int Width = MoveWindowHook::MoveWindowDontResize ? nWidth : MoveWindowHook::width;
+		int Height = MoveWindowHook::MoveWindowDontResize ? nHeight : MoveWindowHook::height;
+		int PosX = MoveWindowHook::MoveWindowDontReposition ? X : MoveWindowHook::posx;
+		int PosY = MoveWindowHook::MoveWindowDontReposition ? Y : MoveWindowHook::posy;
+
+		return MoveWindow(hWnd, PosX, PosY, Width, Height, bRepaint);
+	}
+
+	void MoveWindowHook::ShowGuiStatus()
+	{
+		int pos[2] = { posx, posy };
+		ImGui::SliderInt2("Position", &pos[0], -5000, 5000);
+		posx = pos[0];
+		posy = pos[1];
+
+		int size[2] = { width, height };
+		ImGui::SliderInt2("Size", &size[0], 0, 5000);
+		width = size[0];
+		height = size[1];
+	}
+
+	void MoveWindowHook::InstallImpl()
+	{
+		hookInfo = std::get<1>(InstallNamedHook(L"user32", "MoveWindow", Hook_MoveWindow));
+	}
+
+	void MoveWindowHook::UninstallImpl()
+	{
+		UninstallHook(&hookInfo);
+	}
+
+}

--- a/src/ProtoInput/ProtoInputHooks/MoveWindowHook.h
+++ b/src/ProtoInput/ProtoInputHooks/MoveWindowHook.h
@@ -1,0 +1,35 @@
+#pragma once
+#include "Hook.h"
+#include "InstallHooks.h"
+
+namespace Proto
+{
+
+	class MoveWindowHook final : public Hook
+	{
+	private:
+		HookInfo hookInfo{};
+
+	public:
+		static int width;
+		static int height;
+		static int posx;
+		static int posy;
+
+		static bool MoveWindowDontResize;
+		static bool MoveWindowDontReposition;
+
+		const char* GetHookName() const override { return "Move Window"; }
+		const char* GetHookDescription() const override
+		{
+			return
+				"When the game tries to reposition/resize its game window, this hook forces it to a fixed position and size. ";
+		}
+		bool HasGuiStatus() const override { return false; }
+		void ShowGuiStatus() override;
+		void InstallImpl() override;
+		void UninstallImpl() override;
+	};
+
+}
+

--- a/src/ProtoInput/ProtoInputHooks/PipeCommunication.cpp
+++ b/src/ProtoInput/ProtoInputHooks/PipeCommunication.cpp
@@ -23,6 +23,8 @@
 #include "ClipCursorHook.h"
 #include "FakeMouseKeyboard.h"
 #include "CursorVisibilityHook.h"
+#include "MoveWindowHook.h"
+#include "AdjustWindowRectHook.h"
 
 namespace Proto
 {
@@ -267,12 +269,13 @@ DWORD WINAPI PipeThread(LPVOID lpParameter)
 				const auto body = reinterpret_cast<ProtoPipe::PipeMessageSetupMessagesToSend*>(messageBuffer);
 
 				printf("Received setup messages to send, send mouse move = %d, send mouse button = %d, send mouse wheel = %d, send keyboard = %d\n", 
-					   body->sendMouseMoveMessages ? 1 : 0, body->sendMouseButtonMessages ? 1 : 0, body->sendMouseWheelMessages ? 1 : 0, body->sendKeyboardPressMessages ? 1 : 0);
+					   body->sendMouseMoveMessages ? 1 : 0, body->sendMouseButtonMessages ? 1 : 0, body->sendMouseWheelMessages ? 1 : 0, body->sendKeyboardPressMessages ? 1 : 0, body->sendMouseDblClkMessages ? 1 : 0);
 
 				RawInput::rawInputState.sendMouseMoveMessages = body->sendMouseMoveMessages;
 				RawInput::rawInputState.sendMouseButtonMessages = body->sendMouseButtonMessages;
 				RawInput::rawInputState.sendMouseWheelMessages = body->sendMouseWheelMessages;
 				RawInput::rawInputState.sendKeyboardPressMessages = body->sendKeyboardPressMessages;
+				RawInput::rawInputState.sendMouseDblClkMessages = body->sendMouseDblClkMessages;
 					
 				break;
 			}
@@ -393,6 +396,26 @@ DWORD WINAPI PipeThread(LPVOID lpParameter)
 
 				break;
 			}
+			case ProtoPipe::PipeMessageType::SetSetWindowPosDontResize:
+			{
+				const auto body = reinterpret_cast<ProtoPipe::PipeMessageSetSetWindowPosDontResize*>(messageBuffer);
+
+				printf("Received SetSetWindowPosDontResize, enabled = %d\n", body->SetWindowPosDontResize);
+
+				SetWindowPosHook::SetWindowPosDontResize = body->SetWindowPosDontResize;
+
+				break;
+			}
+			case ProtoPipe::PipeMessageType::SetSetWindowPosDontReposition:
+			{
+				const auto body = reinterpret_cast<ProtoPipe::PipeMessageSetSetWindowPosDontReposition*>(messageBuffer);
+
+				printf("Received SetSetWindowPosDontReposition, enabled = %d\n", body->SetWindowPosDontReposition);
+
+				SetWindowPosHook::SetWindowPosDontReposition = body->SetWindowPosDontReposition;
+
+				break;
+			}
 			case ProtoPipe::PipeMessageType::SetCreateSingleHIDName:
 			{
 				const auto body = reinterpret_cast<ProtoPipe::PipeMessageSetCreateSingleHIDName*>(messageBuffer);
@@ -452,6 +475,62 @@ DWORD WINAPI PipeThread(LPVOID lpParameter)
 				printf("Received ShowCursorWhenImageUpdated, enabled = %d\n", body->ShowCursorWhenImageUpdated);
 
 				CursorVisibilityHook::ShowCursorWhenImageUpdated = body->ShowCursorWhenImageUpdated;
+
+				break;
+			}
+			case ProtoPipe::PipeMessageType::SetPutMouseInsideWindow:
+			{
+				const auto body = reinterpret_cast<ProtoPipe::PipeMessagePutMouseInsideWindow*>(messageBuffer);
+
+				printf("Received PutMouseInsideWindow, enabled = %d\n", body->PutMouseInsideWindow);
+
+				FakeMouseKeyboard::PutMouseInsideWindow = body->PutMouseInsideWindow;
+
+				break;
+			}
+			case ProtoPipe::PipeMessageType::SetMoveWindowSettings:
+			{
+				const auto body = reinterpret_cast<ProtoPipe::PipeMessageSetMoveWindowSettings*>(messageBuffer);
+
+				printf("Received SetMoveWindowSettings. Pos (%d, %d), Size (%d,%d)\n", body->posx, body->posy, body->width, body->height);
+
+				MoveWindowHook::posx = body->posx;
+				MoveWindowHook::posy = body->posy;
+				MoveWindowHook::width = body->width;
+				MoveWindowHook::height = body->height;
+
+				break;
+			}
+			case ProtoPipe::PipeMessageType::SetMoveWindowDontResize:
+			{
+				const auto body = reinterpret_cast<ProtoPipe::PipeMessageSetMoveWindowDontResize*>(messageBuffer);
+
+				printf("Received SetMoveWindowDontResize, enabled = %d\n", body->MoveWindowDontResize);
+
+				MoveWindowHook::MoveWindowDontResize = body->MoveWindowDontResize;
+
+				break;
+			}
+			case ProtoPipe::PipeMessageType::SetMoveWindowDontReposition:
+			{
+				const auto body = reinterpret_cast<ProtoPipe::PipeMessageSetMoveWindowDontReposition*>(messageBuffer);
+
+				printf("Received SetMoveWindowDontReposition, enabled = %d\n", body->MoveWindowDontReposition);
+
+				MoveWindowHook::MoveWindowDontReposition = body->MoveWindowDontReposition;
+
+				break;
+			}
+			case ProtoPipe::PipeMessageType::SetAdjustWindowRectSettings:
+			{
+				const auto body = reinterpret_cast<ProtoPipe::PipeMessageSetAdjustWindowRectSettings*>(messageBuffer);
+
+				printf("Received SetAdjustWindowRectSettings. Pos (%d, %d), Size (%d,%d)\n", body->posx, body->posy, body->width, body->height);
+
+				AdjustWindowRectHook::posx = body->posx;
+				AdjustWindowRectHook::posy = body->posy;
+				AdjustWindowRectHook::width = body->width;
+				AdjustWindowRectHook::height = body->height;
 
 				break;
 			}

--- a/src/ProtoInput/ProtoInputHooks/ProtoInputHooks.vcxproj
+++ b/src/ProtoInput/ProtoInputHooks/ProtoInputHooks.vcxproj
@@ -189,6 +189,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="AdjustWindowRectHook.h" />
     <ClInclude Include="BlockRawInputHook.h" />
     <ClInclude Include="Cleanup.h" />
     <ClInclude Include="ClipCursorHook.h" />
@@ -222,12 +223,14 @@
     <ClInclude Include="MouseButtonFilter.h" />
     <ClInclude Include="MouseMoveFilter.h" />
     <ClInclude Include="MouseWheelFilter.h" />
+    <ClInclude Include="MoveWindowHook.h" />
     <ClInclude Include="OpenXinputWrapper.h" />
     <ClInclude Include="PipeCommunication.h" />
     <ClInclude Include="pipeinclude\pipeinclude.h" />
     <ClInclude Include="RawInput.h" />
     <ClInclude Include="RawInputFilter.h" />
     <ClInclude Include="RegisterRawInputHook.h" />
+    <ClInclude Include="RemoveBorderHook.h" />
     <ClInclude Include="RenameHandlesHook.h" />
     <ClInclude Include="SetCursorPosHook.h" />
     <ClInclude Include="SetWindowPosHook.h" />
@@ -248,6 +251,7 @@
     <ClCompile Include="..\..\..\lib\imgui\imgui_draw.cpp" />
     <ClCompile Include="..\..\..\lib\imgui\imgui_tables.cpp" />
     <ClCompile Include="..\..\..\lib\imgui\imgui_widgets.cpp" />
+    <ClCompile Include="AdjustWindowRectHook.cpp" />
     <ClCompile Include="BlockRawInputHook.cpp" />
     <ClCompile Include="Cleanup.cpp" />
     <ClCompile Include="ClipCursorHook.cpp" />
@@ -272,10 +276,12 @@
     <ClCompile Include="HwndSelector.cpp" />
     <ClCompile Include="MessageFilterHook.cpp" />
     <ClCompile Include="MessageList.cpp" />
+    <ClCompile Include="MoveWindowHook.cpp" />
     <ClCompile Include="OpenXinputWrapper.cpp" />
     <ClCompile Include="PipeCommunication.cpp" />
     <ClCompile Include="RawInput.cpp" />
     <ClCompile Include="RegisterRawInputHook.cpp" />
+    <ClCompile Include="RemoveBorderHook.cpp" />
     <ClCompile Include="RenameHandlesHook.cpp" />
     <ClCompile Include="SetCursorPosHook.cpp" />
     <ClCompile Include="SetWindowPosHook.cpp" />

--- a/src/ProtoInput/ProtoInputHooks/ProtoInputHooks.vcxproj.filters
+++ b/src/ProtoInput/ProtoInputHooks/ProtoInputHooks.vcxproj.filters
@@ -171,6 +171,15 @@
     <ClInclude Include="WindowStyleHook.h">
       <Filter>Source Files\Hooks</Filter>
     </ClInclude>
+    <ClInclude Include="MoveWindowHook.h">
+      <Filter>Source Files\Hooks</Filter>
+    </ClInclude>
+    <ClInclude Include="AdjustWindowRectHook.h">
+      <Filter>Source Files\Hooks</Filter>
+    </ClInclude>
+    <ClInclude Include="RemoveBorderHook.h">
+      <Filter>Source Files\Hooks</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">
@@ -303,6 +312,15 @@
       <Filter>Source Files\Hooks</Filter>
     </ClCompile>
     <ClCompile Include="WindowStyleHook.cpp">
+      <Filter>Source Files\Hooks</Filter>
+    </ClCompile>
+    <ClCompile Include="MoveWindowHook.cpp">
+      <Filter>Source Files\Hooks</Filter>
+    </ClCompile>
+    <ClCompile Include="AdjustWindowRectHook.cpp">
+      <Filter>Source Files\Hooks</Filter>
+    </ClCompile>
+    <ClCompile Include="RemoveBorderHook.cpp">
       <Filter>Source Files\Hooks</Filter>
     </ClCompile>
   </ItemGroup>

--- a/src/ProtoInput/ProtoInputHooks/RawInput.h
+++ b/src/ProtoInput/ProtoInputHooks/RawInput.h
@@ -21,6 +21,7 @@ struct RawInputState
 	bool sendMouseButtonMessages = false;
 	bool sendMouseMoveMessages = false;
 	bool sendKeyboardPressMessages = false;
+	bool sendMouseDblClkMessages = false;
 
 	// 'Freeze' input means don't send any input to the game, so it doesn't interfere when setting things up
 	bool externalFreezeInput = false;

--- a/src/ProtoInput/ProtoInputHooks/RemoveBorderHook.cpp
+++ b/src/ProtoInput/ProtoInputHooks/RemoveBorderHook.cpp
@@ -1,0 +1,148 @@
+#include "RemoveBorderHook.h"
+
+namespace Proto
+{
+
+	inline void FilterStyle(LONG& style)
+	{
+		style &= ~(WS_BORDER | WS_SYSMENU | WS_DLGFRAME | WS_CAPTION |
+			WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX);
+		style |= WS_VISIBLE | WS_POPUP | WS_CLIPCHILDREN | WS_CLIPSIBLINGS;
+	}
+
+	inline void FilterStylePtr(LONG_PTR& style)
+	{
+		style &= ~(WS_BORDER | WS_SYSMENU | WS_DLGFRAME | WS_CAPTION |
+			WS_THICKFRAME | WS_MINIMIZEBOX | WS_MAXIMIZEBOX);
+		style |= WS_VISIBLE | WS_POPUP | WS_CLIPCHILDREN | WS_CLIPSIBLINGS;
+	}
+
+	BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam)
+	{
+		DWORD processId = GetCurrentProcessId();
+		DWORD windowProcessId;
+		GetWindowThreadProcessId(hwnd, &windowProcessId);
+
+		if (windowProcessId == processId &&
+			GetWindow(hwnd, GW_OWNER) == NULL &&
+			IsWindowVisible(hwnd))
+		{
+			*(HWND*)lParam = hwnd; // Store the found window handle
+			return FALSE; // Stop enumeration
+		}
+		return TRUE; // Continue enumeration
+	}
+
+	HWND GetMainWindow()
+	{
+		HWND mainWindow = NULL;
+		EnumWindows(EnumWindowsProc, (LPARAM)&mainWindow);
+		return mainWindow;
+	}
+
+	void RemoveWindowBorder(HWND hWnd)
+	{
+		if (!hWnd) return;
+
+		RECT windowRect, clientRect;
+		GetWindowRect(hWnd, &windowRect);
+		GetClientRect(hWnd, &clientRect);
+
+		POINT clientTopLeft = { clientRect.left, clientRect.top };
+		ClientToScreen(hWnd, &clientTopLeft);
+
+		int clientWidth = clientRect.right - clientRect.left;
+		int clientHeight = clientRect.bottom - clientRect.top;
+
+		LONG currentStyle = GetWindowLong(hWnd, GWL_STYLE);
+		LONG newStyle = currentStyle;
+		FilterStyle(newStyle);
+
+		RECT newWindowRect = { 0, 0, clientWidth, clientHeight };
+		AdjustWindowRectEx(&newWindowRect, newStyle, FALSE, GetWindowLong(hWnd, GWL_EXSTYLE));
+
+		SetWindowLong(hWnd, GWL_STYLE, newStyle);
+
+		SetWindowPos(hWnd,
+			NULL,
+			clientTopLeft.x, // Position where the client area was
+			clientTopLeft.y,
+			newWindowRect.right - newWindowRect.left,
+			newWindowRect.bottom - newWindowRect.top,
+			SWP_NOZORDER | SWP_FRAMECHANGED);
+	}
+
+	LONG WINAPI AltHook_SetWindowLongA(
+		HWND hWnd,
+		int  nIndex,
+		LONG dwNewLong
+	)
+	{
+		if (nIndex == GWL_STYLE)
+		{
+			FilterStyle(dwNewLong);
+		}
+		return SetWindowLongA(hWnd, nIndex, dwNewLong);
+	}
+
+	LONG WINAPI AltHook_SetWindowLongW(
+		HWND hWnd,
+		int  nIndex,
+		LONG dwNewLong
+	)
+	{
+		if (nIndex == GWL_STYLE)
+		{
+			FilterStyle(dwNewLong);
+		}
+		return SetWindowLongW(hWnd, nIndex, dwNewLong);
+	}
+
+	LONG_PTR WINAPI AltHook_SetWindowLongPtrA(
+		HWND hWnd,
+		int  nIndex,
+		LONG_PTR dwNewLong
+	)
+	{
+		if (nIndex == GWL_STYLE)
+		{
+			FilterStylePtr(dwNewLong);
+		}
+		return SetWindowLongPtrA(hWnd, nIndex, dwNewLong);
+	}
+
+	LONG_PTR WINAPI AltHook_SetWindowLongPtrW(
+		HWND hWnd,
+		int  nIndex,
+		LONG_PTR dwNewLong
+	)
+	{
+		if (nIndex == GWL_STYLE)
+		{
+			FilterStylePtr(dwNewLong);
+		}
+		return SetWindowLongPtrW(hWnd, nIndex, dwNewLong);
+	}
+
+	void RemoveBorderHook::InstallImpl()
+	{
+		hookInfoA = std::get<1>(InstallNamedHook(L"user32", "SetWindowLongA", AltHook_SetWindowLongA));
+		hookInfoW = std::get<1>(InstallNamedHook(L"user32", "SetWindowLongW", AltHook_SetWindowLongW));
+		hookInfoPtrA = std::get<1>(InstallNamedHook(L"user32", "SetWindowLongPtrA", AltHook_SetWindowLongPtrA));
+		hookInfoPtrW = std::get<1>(InstallNamedHook(L"user32", "SetWindowLongPtrW", AltHook_SetWindowLongPtrW));
+
+		if (HWND hWnd = GetMainWindow())
+		{
+			RemoveWindowBorder(hWnd);
+		}
+	}
+
+	void RemoveBorderHook::UninstallImpl()
+	{
+		UninstallHook(&hookInfoA);
+		UninstallHook(&hookInfoW);
+		UninstallHook(&hookInfoPtrA);
+		UninstallHook(&hookInfoPtrW);
+	}
+
+}

--- a/src/ProtoInput/ProtoInputHooks/RemoveBorderHook.h
+++ b/src/ProtoInput/ProtoInputHooks/RemoveBorderHook.h
@@ -1,0 +1,30 @@
+#pragma once
+#include "Hook.h"
+#include "InstallHooks.h"
+
+namespace Proto
+{
+
+	class RemoveBorderHook final : public Hook
+	{
+	private:
+		HookInfo hookInfoA{};
+		HookInfo hookInfoW{};
+		HookInfo hookInfoPtrA{};
+		HookInfo hookInfoPtrW{};
+
+	public:
+
+		const char* GetHookName() const override { return "Remove Border"; }
+		const char* GetHookDescription() const override
+		{
+			return
+				"Hooks SetWindowLong and SetWindowLongPtr. And maintain the window aspect after the border removal through EnumWindowsProc. ";
+		}
+		bool HasGuiStatus() const override { return false; }
+
+		void InstallImpl() override;
+		void UninstallImpl() override;
+	};
+
+}

--- a/src/ProtoInput/ProtoInputHooks/SetWindowPosHook.cpp
+++ b/src/ProtoInput/ProtoInputHooks/SetWindowPosHook.cpp
@@ -9,9 +9,17 @@ int SetWindowPosHook::height = 0;
 int SetWindowPosHook::posx = 0;
 int SetWindowPosHook::posy = 0;
 
+bool SetWindowPosHook::SetWindowPosDontResize = false;
+bool SetWindowPosHook::SetWindowPosDontReposition = false;
+
 BOOL WINAPI Hook_SetWindowPos(HWND hWnd, HWND hWndInsertAfter, int X, int Y, int cx, int cy, UINT uFlags)
 {
-	return SetWindowPos(hWnd, hWndInsertAfter, SetWindowPosHook::posx, SetWindowPosHook::posy, SetWindowPosHook::width, SetWindowPosHook::height, uFlags);
+	int Width = SetWindowPosHook::SetWindowPosDontResize ? cx : SetWindowPosHook::width;
+	int Height = SetWindowPosHook::SetWindowPosDontResize ? cy : SetWindowPosHook::height;
+	int PosX = SetWindowPosHook::SetWindowPosDontReposition ? X : SetWindowPosHook::posx;
+	int PosY = SetWindowPosHook::SetWindowPosDontReposition ? Y : SetWindowPosHook::posy;
+
+	return SetWindowPos(hWnd, hWndInsertAfter, PosX, PosY, Width, Height, uFlags);
 }
 
 void SetWindowPosHook::ShowGuiStatus()

--- a/src/ProtoInput/ProtoInputHooks/SetWindowPosHook.h
+++ b/src/ProtoInput/ProtoInputHooks/SetWindowPosHook.h
@@ -15,6 +15,9 @@ public:
 	static int height;
 	static int posx;
 	static int posy;
+
+	static bool SetWindowPosDontResize;
+	static bool SetWindowPosDontReposition;
 	
 	const char* GetHookName() const override { return "Set Window Position"; }
 	const char* GetHookDescription() const override

--- a/src/ProtoInput/ProtoInputHooks/pipeinclude/pipeinclude.h
+++ b/src/ProtoInput/ProtoInputHooks/pipeinclude/pipeinclude.h
@@ -26,12 +26,19 @@ enum class PipeMessageType
 	SetDinputDeviceGuid,
 	SetDinputHookGetDeviceState,
 	SetSetWindowPosSettings,
+	SetSetWindowPosDontResize,
+	SetSetWindowPosDontReposition,
 	SetCreateSingleHIDName,
 	SetClipCursorHookOptions,
 	SetAllowFakeCursorOutOfBounds,
 	SetToggleCursorVisibilityShortcut,
 	SetRawInputBypass,
-	SetShowCursorWhenImageUpdated
+	SetShowCursorWhenImageUpdated,
+	SetPutMouseInsideWindow,
+	SetMoveWindowSettings,
+	SetMoveWindowDontResize,
+	SetMoveWindowDontReposition,
+	SetAdjustWindowRectSettings
 };
 
 struct PipeMessageHeader
@@ -88,6 +95,7 @@ struct PipeMessageSetupMessagesToSend
 	bool sendMouseButtonMessages;
 	bool sendMouseMoveMessages;
 	bool sendKeyboardPressMessages;
+	bool sendMouseDblClkMessages;
 };
 
 struct PipeMessageSetDrawFakeCursor
@@ -153,6 +161,16 @@ struct PipeMessageSetSetWindowPosSettings
 	int height;
 };
 
+struct PipeMessageSetSetWindowPosDontResize
+{
+	bool SetWindowPosDontResize;
+};
+
+struct PipeMessageSetSetWindowPosDontReposition
+{
+	bool SetWindowPosDontReposition;
+};
+
 struct PipeMessageSetCreateSingleHIDName
 {
 	wchar_t buff[1000]{};
@@ -183,6 +201,37 @@ struct PipeMessageSetRawInputBypass
 struct PipeMessageShowCursorWhenImageUpdated
 {
 	bool ShowCursorWhenImageUpdated;
+};
+
+struct PipeMessagePutMouseInsideWindow
+{
+	bool PutMouseInsideWindow;
+};
+
+struct PipeMessageSetMoveWindowSettings
+{
+	int posx;
+	int posy;
+	int width;
+	int height;
+};
+
+struct PipeMessageSetMoveWindowDontResize
+{
+	bool MoveWindowDontResize;
+};
+
+struct PipeMessageSetMoveWindowDontReposition
+{
+	bool MoveWindowDontReposition;
+};
+
+struct PipeMessageSetAdjustWindowRectSettings
+{
+	int posx;
+	int posy;
+	int width;
+	int height;
 };
 
 }

--- a/src/ProtoInput/ProtoInputHost/Profiles.h
+++ b/src/ProtoInput/ProtoInputHost/Profiles.h
@@ -76,6 +76,8 @@ struct Profile
 	bool useFakeClipCursor = true;
 
 	bool showCursorWhenImageUpdated = false;
+
+	bool PutMouseInsideWindow = false;
 	
 	bool drawFakeMouseCursor = true;
 	bool allowMouseOutOfBounds = false;

--- a/src/ProtoInput/ProtoInputLoader/Inject.cpp
+++ b/src/ProtoInput/ProtoInputLoader/Inject.cpp
@@ -262,7 +262,7 @@ extern "C" __declspec(dllexport) void AddNamedPipeToRename(ProtoInstanceHandle i
 	AddHandleToRenameImpl(instanceHandle, name, true);
 }
 
-extern "C" __declspec(dllexport) void SetupMessagesToSend(ProtoInstanceHandle instanceHandle, bool sendMouseWheelMessages, bool sendMouseButtonMessages, bool sendMouseMoveMessages, bool sendKeyboardPressMessages)
+extern "C" __declspec(dllexport) void SetupMessagesToSend(ProtoInstanceHandle instanceHandle, bool sendMouseWheelMessages, bool sendMouseButtonMessages, bool sendMouseMoveMessages, bool sendKeyboardPressMessages, bool sendMouseDblClkMessages)
 {
 	if (const auto find = Proto::instances.find(instanceHandle); find != Proto::instances.end())
 	{
@@ -275,7 +275,8 @@ extern "C" __declspec(dllexport) void SetupMessagesToSend(ProtoInstanceHandle in
 			sendMouseWheelMessages,
 			sendMouseButtonMessages,
 			sendMouseMoveMessages,
-			sendKeyboardPressMessages
+			sendKeyboardPressMessages,
+			sendMouseDblClkMessages
 		};
 
 		ProtoSendPipeMessage(instance.pipeHandle, ProtoPipe::PipeMessageType::SetupMessagesToSend, &message);
@@ -374,6 +375,40 @@ void SetSetWindowPosSettings(ProtoInstanceHandle instanceHandle, int posx, int p
 		};
 
 		ProtoSendPipeMessage(instance.pipeHandle, ProtoPipe::PipeMessageType::SetSetWindowPosSettings, &message);
+	}
+}
+
+void SetSetWindowPosDontResize(ProtoInstanceHandle instanceHandle, bool enabled)
+{
+	if (const auto find = Proto::instances.find(instanceHandle); find != Proto::instances.end())
+	{
+		auto& instance = find->second;
+
+		WaitClientConnect(instance);
+
+		ProtoPipe::PipeMessageSetSetWindowPosDontResize message
+		{
+			enabled
+		};
+
+		ProtoSendPipeMessage(instance.pipeHandle, ProtoPipe::PipeMessageType::SetSetWindowPosDontResize, &message);
+	}
+}
+
+void SetSetWindowPosDontReposition(ProtoInstanceHandle instanceHandle, bool enabled)
+{
+	if (const auto find = Proto::instances.find(instanceHandle); find != Proto::instances.end())
+	{
+		auto& instance = find->second;
+
+		WaitClientConnect(instance);
+
+		ProtoPipe::PipeMessageSetSetWindowPosDontReposition message
+		{
+			enabled
+		};
+
+		ProtoSendPipeMessage(instance.pipeHandle, ProtoPipe::PipeMessageType::SetSetWindowPosDontReposition, &message);
 	}
 }
 
@@ -489,5 +524,90 @@ void SetShowCursorWhenImageUpdated(ProtoInstanceHandle instanceHandle, bool enab
 		};
 
 		ProtoSendPipeMessage(instance.pipeHandle, ProtoPipe::PipeMessageType::SetShowCursorWhenImageUpdated, &message);
+	}
+}
+
+void SetPutMouseInsideWindow(ProtoInstanceHandle instanceHandle, bool enabled)
+{
+	if (const auto find = Proto::instances.find(instanceHandle); find != Proto::instances.end())
+	{
+		auto& instance = find->second;
+
+		WaitClientConnect(instance);
+
+		ProtoPipe::PipeMessagePutMouseInsideWindow message
+		{
+			enabled
+		};
+
+		ProtoSendPipeMessage(instance.pipeHandle, ProtoPipe::PipeMessageType::SetPutMouseInsideWindow, &message);
+	}
+}
+
+void SetMoveWindowSettings(ProtoInstanceHandle instanceHandle, int posx, int posy, int width, int height)
+{
+	if (const auto find = Proto::instances.find(instanceHandle); find != Proto::instances.end())
+	{
+		auto& instance = find->second;
+
+		WaitClientConnect(instance);
+
+		ProtoPipe::PipeMessageSetMoveWindowSettings message
+		{
+			posx, posy, width, height
+		};
+
+		ProtoSendPipeMessage(instance.pipeHandle, ProtoPipe::PipeMessageType::SetMoveWindowSettings, &message);
+	}
+}
+
+void SetMoveWindowDontResize(ProtoInstanceHandle instanceHandle, bool enabled)
+{
+	if (const auto find = Proto::instances.find(instanceHandle); find != Proto::instances.end())
+	{
+		auto& instance = find->second;
+
+		WaitClientConnect(instance);
+
+		ProtoPipe::PipeMessageSetMoveWindowDontResize message
+		{
+			enabled
+		};
+
+		ProtoSendPipeMessage(instance.pipeHandle, ProtoPipe::PipeMessageType::SetMoveWindowDontResize, &message);
+	}
+}
+
+void SetMoveWindowDontReposition(ProtoInstanceHandle instanceHandle, bool enabled)
+{
+	if (const auto find = Proto::instances.find(instanceHandle); find != Proto::instances.end())
+	{
+		auto& instance = find->second;
+
+		WaitClientConnect(instance);
+
+		ProtoPipe::PipeMessageSetMoveWindowDontReposition message
+		{
+			enabled
+		};
+
+		ProtoSendPipeMessage(instance.pipeHandle, ProtoPipe::PipeMessageType::SetMoveWindowDontReposition, &message);
+	}
+}
+
+void SetAdjustWindowRectSettings(ProtoInstanceHandle instanceHandle, int posx, int posy, int width, int height)
+{
+	if (const auto find = Proto::instances.find(instanceHandle); find != Proto::instances.end())
+	{
+		auto& instance = find->second;
+
+		WaitClientConnect(instance);
+
+		ProtoPipe::PipeMessageSetAdjustWindowRectSettings message
+		{
+			posx, posy, width, height
+		};
+
+		ProtoSendPipeMessage(instance.pipeHandle, ProtoPipe::PipeMessageType::SetAdjustWindowRectSettings, &message);
 	}
 }

--- a/src/ProtoInput/ProtoInputLoader/include/protoloader.h
+++ b/src/ProtoInput/ProtoInputLoader/include/protoloader.h
@@ -24,7 +24,10 @@ enum ProtoHookIDs : unsigned int
 	BlockRawInputHookID,
 	FindWindowHookID,
 	CreateSingleHIDHookID,
-	WindowStyleHookID
+	WindowStyleHookID,
+	MoveWindowHookID,
+	AdjustWindowRectHookID,
+	RemoveBorderHookID
 };
 
 enum ProtoMessageFilterIDs : unsigned int
@@ -68,7 +71,7 @@ extern "C" __declspec(dllexport) void UpdateMainWindowHandle(ProtoInstanceHandle
 extern "C" __declspec(dllexport) void SetupState(ProtoInstanceHandle instanceHandle, int instanceIndex);
 
 extern "C" __declspec(dllexport) void SetupMessagesToSend(ProtoInstanceHandle instanceHandle,
-														  bool sendMouseWheelMessages = true, bool sendMouseButtonMessages = true, bool sendMouseMoveMessages = true, bool sendKeyboardPressMessages = true);
+														  bool sendMouseWheelMessages = true, bool sendMouseButtonMessages = true, bool sendMouseMoveMessages = true, bool sendKeyboardPressMessages = true, bool sendMouseDblClkMessages = false);
 
 extern "C" __declspec(dllexport) void StartFocusMessageLoop(ProtoInstanceHandle instanceHandle, int milliseconds = 5,
 															bool wm_activate = true, bool wm_activateapp = true, bool wm_ncactivate = true, bool wm_setfocus = true, bool wm_mouseactivate = true);
@@ -112,6 +115,10 @@ extern "C" __declspec(dllexport) void DinputHookAlsoHooksGetDeviceState(ProtoIns
 
 extern "C" __declspec(dllexport) void SetSetWindowPosSettings(ProtoInstanceHandle instanceHandle, int posx, int posy, int width, int height);
 
+extern "C" __declspec(dllexport) void SetSetWindowPosDontResize(ProtoInstanceHandle instanceHandle, bool enabled);
+
+extern "C" __declspec(dllexport) void SetSetWindowPosDontReposition(ProtoInstanceHandle instanceHandle, bool enabled);
+
 extern "C" __declspec(dllexport) void SetCreateSingleHIDName(ProtoInstanceHandle instanceHandle, const wchar_t* name);
 
 extern "C" __declspec(dllexport) void SetCursorClipOptions(ProtoInstanceHandle instanceHandle, bool useFakeClipCursor);
@@ -123,3 +130,13 @@ extern "C" __declspec(dllexport) void SetToggleFakeCursorVisibilityShortcut(Prot
 extern "C" __declspec(dllexport) void SetRawInputBypass(ProtoInstanceHandle instanceHandle, bool enabled);
 
 extern "C" __declspec(dllexport) void SetShowCursorWhenImageUpdated(ProtoInstanceHandle instanceHandle, bool enabled);
+
+extern "C" __declspec(dllexport) void SetPutMouseInsideWindow(ProtoInstanceHandle instanceHandle, bool enabled);
+
+extern "C" __declspec(dllexport) void SetMoveWindowSettings(ProtoInstanceHandle instanceHandle, int posx, int posy, int width, int height);
+
+extern "C" __declspec(dllexport) void SetMoveWindowDontResize(ProtoInstanceHandle instanceHandle, bool enabled);
+
+extern "C" __declspec(dllexport) void SetMoveWindowDontReposition(ProtoInstanceHandle instanceHandle, bool enabled);
+
+extern "C" __declspec(dllexport) void SetAdjustWindowRectSettings(ProtoInstanceHandle instanceHandle, int posx, int posy, int width, int height);


### PR DESCRIPTION
- `MoveWindowHook` is very similar to `SetWindowPos` which some games calls that function.
- `AdjustWindowRectHook` unexpectedly it adjust the window before it being created which mostly need either startup inject or at the very early.
- `RemoveBorderHook` it's a copy of `SetWindowStyleHook` with window RECT adjust and removes the border through EnumWindowsProc.

- Add extra options for `SetWindowPosDontResize`, `SetWindowPosDontReposition`, `MoveWindowDontResize` and `MoveWindowDontReposition` .
- Add `PutMouseInsideWindow` to put the mouse inside the window.
- Add `sendMouseDblClkMessages` to allow double click messages.