### PR TITLE
Added the window filtering logic from HwndSelector.

### DIFF
--- a/src/ProtoInput/ProtoInputHooks/AdjustWindowRectHook.cpp
+++ b/src/ProtoInput/ProtoInputHooks/AdjustWindowRectHook.cpp
@@ -9,8 +9,6 @@ namespace Proto
 	int AdjustWindowRectHook::posx = 0;
 	int AdjustWindowRectHook::posy = 0;
 
-	RECT AdjustWindowRectHook::wr;
-
 	BOOL WINAPI Hook_AdjustWindowRect(LPRECT lpRect, DWORD dwStyle, BOOL bMenu)
 	{
 		lpRect->top = AdjustWindowRectHook::posy;

--- a/src/ProtoInput/ProtoInputHooks/AdjustWindowRectHook.h
+++ b/src/ProtoInput/ProtoInputHooks/AdjustWindowRectHook.h
@@ -17,15 +17,13 @@ namespace Proto
 		static int posx;
 		static int posy;
 
-		static RECT wr;
-
 		const char* GetHookName() const override { return "Adjust Window Rectangle"; }
 		const char* GetHookDescription() const override
 		{
 			return
 				"Hooks AdjustWindowRect and AdjustWindowRectEx. And calculates the required size of the window rectangle. ";
 		}
-		bool HasGuiStatus() const override { return false; }
+		bool HasGuiStatus() const override { return true; }
 		void ShowGuiStatus() override;
 		void InstallImpl() override;
 		void UninstallImpl() override;

--- a/src/ProtoInput/ProtoInputHooks/FakeMouseKeyboard.cpp
+++ b/src/ProtoInput/ProtoInputHooks/FakeMouseKeyboard.cpp
@@ -9,6 +9,8 @@ FakeMouseState FakeMouseKeyboard::mouseState{};
 FakeKeyboardState FakeMouseKeyboard::keyboardState{};
 
 bool FakeMouseKeyboard::PutMouseInsideWindow = false;
+bool FakeMouseKeyboard::DefaultTopLeftMouseBounds = false;
+bool FakeMouseKeyboard::DefaultBottomRightMouseBounds = false;
 
 void FakeMouseKeyboard::AddMouseDelta(int dx, int dy)
 {
@@ -25,13 +27,24 @@ void FakeMouseKeyboard::AddMouseDelta(int dx, int dy)
 			if (mouseState.y < min)
 				mouseState.y = min;
 		}
-		else
+		else if (PutMouseInsideWindow)
 		{
-			int min = mouseState.extendMouseBounds ? -100 : 0;
-			if (mouseState.x < min)
-				mouseState.x = min;
-			if (mouseState.y < min)
-				mouseState.y = min;
+			if (!DefaultTopLeftMouseBounds)
+			{
+				int min = mouseState.extendMouseBounds ? -100 : 0;
+				if (mouseState.x < min)
+					mouseState.x = min;
+				if (mouseState.y < min)
+					mouseState.y = min;
+			}
+			else if (DefaultTopLeftMouseBounds)
+			{
+				int min = mouseState.extendMouseBounds ? -100 : -1;
+				if (mouseState.x < min)
+					mouseState.x = min;
+				if (mouseState.y < min)
+					mouseState.y = min;
+			}
 		}
 
 		if (!PutMouseInsideWindow)
@@ -42,13 +55,23 @@ void FakeMouseKeyboard::AddMouseDelta(int dx, int dy)
 			if (int max = mouseState.extendMouseBounds ? HwndSelector::windowHeight + 100 : HwndSelector::windowHeight; mouseState.y > max)
 				mouseState.y = max;
 		}
-		else
+		else if (PutMouseInsideWindow)
 		{
-			if (int max = mouseState.extendMouseBounds ? HwndSelector::windowWidth + 1100 : HwndSelector::windowWidth; mouseState.x > max)
-				mouseState.x = max - 1;
+			if (!DefaultBottomRightMouseBounds)
+			{
+				if (int max = mouseState.extendMouseBounds ? HwndSelector::windowWidth + 1100 : HwndSelector::windowWidth; mouseState.x > max)
+					mouseState.x = max - 1;
 
-			if (int max = mouseState.extendMouseBounds ? HwndSelector::windowHeight + 700 : HwndSelector::windowHeight; mouseState.y > max)
-				mouseState.y = max - 1;
+				if (int max = mouseState.extendMouseBounds ? HwndSelector::windowHeight + 700 : HwndSelector::windowHeight; mouseState.y > max)
+					mouseState.y = max - 1;
+			}
+			else if (DefaultBottomRightMouseBounds)
+			{
+				if (int max = mouseState.extendMouseBounds ? HwndSelector::windowWidth + 1100 : HwndSelector::windowWidth; mouseState.x > max)
+					mouseState.x = max;
+				if (int max = mouseState.extendMouseBounds ? HwndSelector::windowHeight + 700 : HwndSelector::windowHeight; mouseState.y > max)
+					mouseState.y = max;
+			}
 		}
 		
 		if (mouseState.hasClipCursor)
@@ -82,13 +105,24 @@ void FakeMouseKeyboard::SetMousePos(int x, int y)
 			if (mouseState.y < min)
 				mouseState.y = min;
 		}
-		else
+		else if (PutMouseInsideWindow)
 		{
-			int min = mouseState.extendMouseBounds ? -100 : 0;
-			if (mouseState.x < min)
-				mouseState.x = min;
-			if (mouseState.y < min)
-				mouseState.y = min;
+			if (!DefaultTopLeftMouseBounds)
+			{
+				int min = mouseState.extendMouseBounds ? -100 : 0;
+				if (mouseState.x < min)
+					mouseState.x = min;
+				if (mouseState.y < min)
+					mouseState.y = min;
+			}
+			else if (DefaultTopLeftMouseBounds)
+			{
+				int min = mouseState.extendMouseBounds ? -100 : -1;
+				if (mouseState.x < min)
+					mouseState.x = min;
+				if (mouseState.y < min)
+					mouseState.y = min;
+			}
 		}
 
 		if (!PutMouseInsideWindow)
@@ -99,13 +133,23 @@ void FakeMouseKeyboard::SetMousePos(int x, int y)
 			if (int max = mouseState.extendMouseBounds ? HwndSelector::windowHeight + 100 : HwndSelector::windowHeight; mouseState.y > max)
 				mouseState.y = max;
 		}
-		else
+		else if (PutMouseInsideWindow)
 		{
-			if (int max = mouseState.extendMouseBounds ? HwndSelector::windowWidth + 1100 : HwndSelector::windowWidth; mouseState.x > max)
-				mouseState.x = max - 1;
+			if (!DefaultBottomRightMouseBounds)
+			{
+				if (int max = mouseState.extendMouseBounds ? HwndSelector::windowWidth + 1100 : HwndSelector::windowWidth; mouseState.x > max)
+					mouseState.x = max - 1;
+				if (int max = mouseState.extendMouseBounds ? HwndSelector::windowHeight + 700 : HwndSelector::windowHeight; mouseState.y > max)
+					mouseState.y = max - 1;
+			}
+			else if (DefaultBottomRightMouseBounds)
+			{
+				if (int max = mouseState.extendMouseBounds ? HwndSelector::windowWidth + 1100 : HwndSelector::windowWidth; mouseState.x > max)
+					mouseState.x = max;
 
-			if (int max = mouseState.extendMouseBounds ? HwndSelector::windowHeight + 700 : HwndSelector::windowHeight; mouseState.y > max)
-				mouseState.y = max - 1;
+				if (int max = mouseState.extendMouseBounds ? HwndSelector::windowHeight + 700 : HwndSelector::windowHeight; mouseState.y > max)
+					mouseState.y = max;
+			}
 		}
 
 		if (mouseState.hasClipCursor)

--- a/src/ProtoInput/ProtoInputHooks/FakeMouseKeyboard.h
+++ b/src/ProtoInput/ProtoInputHooks/FakeMouseKeyboard.h
@@ -58,6 +58,9 @@ public:
 
 	// Some games must use the exact window rect to determine the edge of the window.
 	static bool PutMouseInsideWindow;
+	// IgnoreTopLeft and IgnoreBottomRight for PutMouseInsideWindow
+	static bool DefaultTopLeftMouseBounds;
+	static bool DefaultBottomRightMouseBounds;
 
 	static unsigned int GetMouseMkFlags()
 	{

--- a/src/ProtoInput/ProtoInputHooks/GetCursorPosHook.cpp
+++ b/src/ProtoInput/ProtoInputHooks/GetCursorPosHook.cpp
@@ -17,14 +17,20 @@ BOOL WINAPI Hook_GetCursorPos(LPPOINT lpPoint)
 		{
 			int clientWidth = HwndSelector::windowWidth;
 			int clientHeight = HwndSelector::windowHeight;
-			if (lpPoint->y < 1)
-				lpPoint->y = 0;  // Top edge
-			if (lpPoint->x < 1)
-				lpPoint->x = 0;  // Left edge
-			if (lpPoint->y > clientHeight - 1)
-				lpPoint->y = clientHeight - 1;  // Bottom edge
-			if (lpPoint->x > clientWidth - 1)
-				lpPoint->x = clientWidth - 1;  // Right edge
+			if (!FakeMouseKeyboard::DefaultTopLeftMouseBounds)
+			{
+				if (lpPoint->y < 1)
+					lpPoint->y = 0;  // Top edge
+				if (lpPoint->x < 1)
+					lpPoint->x = 0;  // Left edge
+			}
+			if (!FakeMouseKeyboard::DefaultBottomRightMouseBounds)
+			{
+				if (lpPoint->y > clientHeight - 1)
+					lpPoint->y = clientHeight - 1;  // Bottom edge
+				if (lpPoint->x > clientWidth - 1)
+					lpPoint->x = clientWidth - 1;  // Right edge
+			}
 		}
 		ClientToScreen((HWND)HwndSelector::GetSelectedHwnd(), lpPoint);
 	}

--- a/src/ProtoInput/ProtoInputHooks/PipeCommunication.cpp
+++ b/src/ProtoInput/ProtoInputHooks/PipeCommunication.cpp
@@ -499,6 +499,26 @@ DWORD WINAPI PipeThread(LPVOID lpParameter)
 
 				break;
 			}
+			case ProtoPipe::PipeMessageType::SetDefaultTopLeftMouseBounds:
+			{
+				const auto body = reinterpret_cast<ProtoPipe::PipeMessageDefaultTopLeftMouseBounds*>(messageBuffer);
+
+				printf("Received DefaultTopLeftMouseBounds, enabled = %d\n", body->DefaultTopLeftMouseBounds);
+
+				FakeMouseKeyboard::DefaultTopLeftMouseBounds = body->DefaultTopLeftMouseBounds;
+
+				break;
+			}
+			case ProtoPipe::PipeMessageType::SetDefaultBottomRightMouseBounds:
+			{
+				const auto body = reinterpret_cast<ProtoPipe::PipeMessageDefaultBottomRightMouseBounds*>(messageBuffer);
+
+				printf("Received DefaultBottomRightMouseBounds, enabled = %d\n", body->DefaultBottomRightMouseBounds);
+
+				FakeMouseKeyboard::DefaultBottomRightMouseBounds = body->DefaultBottomRightMouseBounds;
+
+				break;
+			}
 			case ProtoPipe::PipeMessageType::SetMoveWindowSettings:
 			{
 				const auto body = reinterpret_cast<ProtoPipe::PipeMessageSetMoveWindowSettings*>(messageBuffer);

--- a/src/ProtoInput/ProtoInputHooks/PipeCommunication.cpp
+++ b/src/ProtoInput/ProtoInputHooks/PipeCommunication.cpp
@@ -25,6 +25,7 @@
 #include "CursorVisibilityHook.h"
 #include "MoveWindowHook.h"
 #include "AdjustWindowRectHook.h"
+#include "RemoveBorderHook.h"
 
 namespace Proto
 {
@@ -562,6 +563,16 @@ DWORD WINAPI PipeThread(LPVOID lpParameter)
 				AdjustWindowRectHook::posy = body->posy;
 				AdjustWindowRectHook::width = body->width;
 				AdjustWindowRectHook::height = body->height;
+
+				break;
+			}
+			case ProtoPipe::PipeMessageType::SetDontWaitWindowBorder:
+			{
+				const auto body = reinterpret_cast<ProtoPipe::PipeMessageSetDontWaitWindowBorder*>(messageBuffer);
+
+				printf("Received DontWaitWindowBorder, enabled = %d\n", body->DontWaitWindowBorder);
+
+				RemoveBorderHook::DontWaitWindowBorder = body->DontWaitWindowBorder;
 
 				break;
 			}

--- a/src/ProtoInput/ProtoInputHooks/RemoveBorderHook.cpp
+++ b/src/ProtoInput/ProtoInputHooks/RemoveBorderHook.cpp
@@ -1,4 +1,7 @@
 #include "RemoveBorderHook.h"
+#include "Gui.h"
+#include "HwndSelector.h"
+#include "FakeCursor.h"
 
 namespace Proto
 {
@@ -17,17 +20,20 @@ namespace Proto
 		style |= WS_VISIBLE | WS_POPUP | WS_CLIPCHILDREN | WS_CLIPSIBLINGS;
 	}
 
-	BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lParam)
+	BOOL CALLBACK EnumWindowsProc(HWND handle, LPARAM lParam)
 	{
 		DWORD processId = GetCurrentProcessId();
 		DWORD windowProcessId;
-		GetWindowThreadProcessId(hwnd, &windowProcessId);
+		GetWindowThreadProcessId(handle, &windowProcessId);
 
 		if (windowProcessId == processId &&
-			GetWindow(hwnd, GW_OWNER) == NULL &&
-			IsWindowVisible(hwnd))
+			GetWindow(handle, GW_OWNER) == (HWND)0 &&
+			IsWindowVisible(handle) &&
+			handle != (HWND)Proto::ConsoleHwnd &&
+			handle != Proto::ProtoGuiHwnd &&
+			handle != FakeCursor::GetPointerWindow())
 		{
-			*(HWND*)lParam = hwnd; // Store the found window handle
+			*(HWND*)lParam = handle; // Store the found window handle
 			return FALSE; // Stop enumeration
 		}
 		return TRUE; // Continue enumeration

--- a/src/ProtoInput/ProtoInputHooks/RemoveBorderHook.cpp
+++ b/src/ProtoInput/ProtoInputHooks/RemoveBorderHook.cpp
@@ -41,6 +41,7 @@ namespace Proto
 
 	HWND GetMainWindow()
 	{
+		Sleep(1000);
 		HWND mainWindow = NULL;
 		EnumWindows(EnumWindowsProc, (LPARAM)&mainWindow);
 		return mainWindow;

--- a/src/ProtoInput/ProtoInputHooks/RemoveBorderHook.h
+++ b/src/ProtoInput/ProtoInputHooks/RemoveBorderHook.h
@@ -15,6 +15,8 @@ namespace Proto
 
 	public:
 
+		static bool DontWaitWindowBorder;
+
 		const char* GetHookName() const override { return "Remove Border"; }
 		const char* GetHookDescription() const override
 		{

--- a/src/ProtoInput/ProtoInputHooks/RemoveBorderHook.h
+++ b/src/ProtoInput/ProtoInputHooks/RemoveBorderHook.h
@@ -21,7 +21,7 @@ namespace Proto
 			return
 				"Hooks SetWindowLong and SetWindowLongPtr. And maintain the window aspect after the border removal through EnumWindowsProc. ";
 		}
-		bool HasGuiStatus() const override { return false; }
+		bool HasGuiStatus() const override { return true; }
 
 		void InstallImpl() override;
 		void UninstallImpl() override;

--- a/src/ProtoInput/ProtoInputHooks/pipeinclude/pipeinclude.h
+++ b/src/ProtoInput/ProtoInputHooks/pipeinclude/pipeinclude.h
@@ -36,6 +36,8 @@ enum class PipeMessageType
 	SetRawInputBypass,
 	SetShowCursorWhenImageUpdated,
 	SetPutMouseInsideWindow,
+	SetDefaultTopLeftMouseBounds,
+	SetDefaultBottomRightMouseBounds,
 	SetMoveWindowSettings,
 	SetMoveWindowDontResize,
 	SetMoveWindowDontReposition,
@@ -210,6 +212,16 @@ struct PipeMessageShowCursorWhenImageUpdated
 struct PipeMessagePutMouseInsideWindow
 {
 	bool PutMouseInsideWindow;
+};
+
+struct PipeMessageDefaultTopLeftMouseBounds
+{
+	bool DefaultTopLeftMouseBounds;
+};
+
+struct PipeMessageDefaultBottomRightMouseBounds
+{
+	bool DefaultBottomRightMouseBounds;
 };
 
 struct PipeMessageSetMoveWindowSettings

--- a/src/ProtoInput/ProtoInputHooks/pipeinclude/pipeinclude.h
+++ b/src/ProtoInput/ProtoInputHooks/pipeinclude/pipeinclude.h
@@ -41,7 +41,8 @@ enum class PipeMessageType
 	SetMoveWindowSettings,
 	SetMoveWindowDontResize,
 	SetMoveWindowDontReposition,
-	SetAdjustWindowRectSettings
+	SetAdjustWindowRectSettings,
+	SetDontWaitWindowBorder
 };
 
 struct PipeMessageHeader
@@ -248,6 +249,11 @@ struct PipeMessageSetAdjustWindowRectSettings
 	int posy;
 	int width;
 	int height;
+};
+
+struct PipeMessageSetDontWaitWindowBorder
+{
+	bool DontWaitWindowBorder;
 };
 
 }

--- a/src/ProtoInput/ProtoInputHost/Gui.cpp
+++ b/src/ProtoInput/ProtoInputHost/Gui.cpp
@@ -137,6 +137,8 @@ bool Launch()
         if (hookEnabled(RegisterRawInputHookID))        InstallHook(instanceHandle, RegisterRawInputHookID);
         if (hookEnabled(GetRawInputDataHookID))         InstallHook(instanceHandle, GetRawInputDataHookID);
         if (hookEnabled(MessageFilterHookID))           InstallHook(instanceHandle, MessageFilterHookID);
+
+		SetPutMouseInsideWindow(instanceHandle, currentProfile.putMouseInsideWindow);
         if (hookEnabled(GetCursorPosHookID))            InstallHook(instanceHandle, GetCursorPosHookID);
         if (hookEnabled(SetCursorPosHookID))            InstallHook(instanceHandle, SetCursorPosHookID);
         if (hookEnabled(GetKeyStateHookID))             InstallHook(instanceHandle, GetKeyStateHookID);
@@ -179,7 +181,8 @@ bool Launch()
                             currentProfile.sendMouseWheelMessages,
                             currentProfile.sendMouseButtonMessages,
                             currentProfile.sendMouseMovementMessages,
-                            currentProfile.sendKeyboardButtonMessages);
+                            currentProfile.sendKeyboardButtonMessages,
+                            currentProfile.sendMouseDblClkMessages);
 
         if (currentProfile.focusMessageLoop)
             StartFocusMessageLoop(instanceHandle,
@@ -870,6 +873,8 @@ void OptionsMenu()
 	
     ImGui::Checkbox("Show fake cursor when image updated", &currentProfile.showCursorWhenImageUpdated);
 
+    ImGui::Checkbox("Put Mouse Inside Window", &currentProfile.putMouseInsideWindow);
+
     if (ImGui::CollapsingHeader("Message Filters", ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_Leaf))
     {
         for (auto& filter : currentProfile.messageFilters)
@@ -895,6 +900,7 @@ void OptionsMenu()
         ImGui::Checkbox("Send mouse button messages", &currentProfile.sendMouseButtonMessages);
         ImGui::Checkbox("Send mouse wheel messages", &currentProfile.sendMouseWheelMessages);
         ImGui::Checkbox("Send keyboard button messages", &currentProfile.sendKeyboardButtonMessages);
+        ImGui::Checkbox("Send mouse double click messages", &currentProfile.sendMouseDblClkMessages);
 
     }
 

--- a/src/ProtoInput/ProtoInputHost/Profiles.h
+++ b/src/ProtoInput/ProtoInputHost/Profiles.h
@@ -77,7 +77,7 @@ struct Profile
 
 	bool showCursorWhenImageUpdated = false;
 
-	bool PutMouseInsideWindow = false;
+	bool putMouseInsideWindow = false;
 	
 	bool drawFakeMouseCursor = true;
 	bool drawFakeCursorFix = false;
@@ -88,6 +88,7 @@ struct Profile
 	bool sendMouseButtonMessages = true;
 	bool sendMouseWheelMessages = true;
 	bool sendKeyboardButtonMessages = true;
+	bool sendMouseDblClkMessages = false;
 	
 	bool focusMessageLoop = true;
 	bool focusLoopSendWM_ACTIVATE = true;
@@ -125,6 +126,7 @@ struct Profile
 			cereal::make_nvp("sendMouseButtonMessages", sendMouseButtonMessages),
 			cereal::make_nvp("sendMouseWheelMessages", sendMouseWheelMessages),
 			cereal::make_nvp("sendKeyboardButtonMessages", sendKeyboardButtonMessages),
+			cereal::make_nvp("sendMouseDblClkMessages", sendMouseDblClkMessages),
 
 			cereal::make_nvp("focusMessageLoop", focusMessageLoop),
 			cereal::make_nvp("focusLoopSendWM_ACTIVATE", focusLoopSendWM_ACTIVATE),

--- a/src/ProtoInput/ProtoInputLoader/Inject.cpp
+++ b/src/ProtoInput/ProtoInputLoader/Inject.cpp
@@ -662,3 +662,20 @@ void SetAdjustWindowRectSettings(ProtoInstanceHandle instanceHandle, int posx, i
 		ProtoSendPipeMessage(instance.pipeHandle, ProtoPipe::PipeMessageType::SetAdjustWindowRectSettings, &message);
 	}
 }
+
+void SetDontWaitWindowBorder(ProtoInstanceHandle instanceHandle, bool enabled)
+{
+	if (const auto find = Proto::instances.find(instanceHandle); find != Proto::instances.end())
+	{
+		auto& instance = find->second;
+
+		WaitClientConnect(instance);
+
+		ProtoPipe::PipeMessageSetDontWaitWindowBorder message
+		{
+			enabled
+		};
+
+		ProtoSendPipeMessage(instance.pipeHandle, ProtoPipe::PipeMessageType::SetDontWaitWindowBorder, &message);
+	}
+}

--- a/src/ProtoInput/ProtoInputLoader/Inject.cpp
+++ b/src/ProtoInput/ProtoInputLoader/Inject.cpp
@@ -561,6 +561,40 @@ void SetPutMouseInsideWindow(ProtoInstanceHandle instanceHandle, bool enabled)
 	}
 }
 
+void SetDefaultTopLeftMouseBounds(ProtoInstanceHandle instanceHandle, bool enabled)
+{
+	if (const auto find = Proto::instances.find(instanceHandle); find != Proto::instances.end())
+	{
+		auto& instance = find->second;
+
+		WaitClientConnect(instance);
+
+		ProtoPipe::PipeMessageDefaultTopLeftMouseBounds message
+		{
+			enabled
+		};
+
+		ProtoSendPipeMessage(instance.pipeHandle, ProtoPipe::PipeMessageType::SetDefaultTopLeftMouseBounds, &message);
+	}
+}
+
+void SetDefaultBottomRightMouseBounds(ProtoInstanceHandle instanceHandle, bool enabled)
+{
+	if (const auto find = Proto::instances.find(instanceHandle); find != Proto::instances.end())
+	{
+		auto& instance = find->second;
+
+		WaitClientConnect(instance);
+
+		ProtoPipe::PipeMessageDefaultBottomRightMouseBounds message
+		{
+			enabled
+		};
+
+		ProtoSendPipeMessage(instance.pipeHandle, ProtoPipe::PipeMessageType::SetDefaultBottomRightMouseBounds, &message);
+	}
+}
+
 void SetMoveWindowSettings(ProtoInstanceHandle instanceHandle, int posx, int posy, int width, int height)
 {
 	if (const auto find = Proto::instances.find(instanceHandle); find != Proto::instances.end())

--- a/src/ProtoInput/ProtoInputLoader/include/protoloader.h
+++ b/src/ProtoInput/ProtoInputLoader/include/protoloader.h
@@ -146,3 +146,5 @@ extern "C" __declspec(dllexport) void SetMoveWindowDontResize(ProtoInstanceHandl
 extern "C" __declspec(dllexport) void SetMoveWindowDontReposition(ProtoInstanceHandle instanceHandle, bool enabled);
 
 extern "C" __declspec(dllexport) void SetAdjustWindowRectSettings(ProtoInstanceHandle instanceHandle, int posx, int posy, int width, int height);
+
+extern "C" __declspec(dllexport) void SetDontWaitWindowBorder(ProtoInstanceHandle instanceHandle, bool enabled);

--- a/src/ProtoInput/ProtoInputLoader/include/protoloader.h
+++ b/src/ProtoInput/ProtoInputLoader/include/protoloader.h
@@ -135,6 +135,10 @@ extern "C" __declspec(dllexport) void SetShowCursorWhenImageUpdated(ProtoInstanc
 
 extern "C" __declspec(dllexport) void SetPutMouseInsideWindow(ProtoInstanceHandle instanceHandle, bool enabled);
 
+extern "C" __declspec(dllexport) void SetDefaultTopLeftMouseBounds(ProtoInstanceHandle instanceHandle, bool enabled);
+
+extern "C" __declspec(dllexport) void SetDefaultBottomRightMouseBounds(ProtoInstanceHandle instanceHandle, bool enabled);
+
 extern "C" __declspec(dllexport) void SetMoveWindowSettings(ProtoInstanceHandle instanceHandle, int posx, int posy, int width, int height);
 
 extern "C" __declspec(dllexport) void SetMoveWindowDontResize(ProtoInstanceHandle instanceHandle, bool enabled);


### PR DESCRIPTION
Fix `RemoveBorderHook` removes the title bar of ProtoInput window sometimes instead of the game window.

Thanks to @Messenils for finding that.