### PR TITLE
Add a bool to disable the GUI. Add key press fix and more.

### DIFF
--- a/src/ProtoInput/ProtoInputHooks/AdjustWindowRectHook.cpp
+++ b/src/ProtoInput/ProtoInputHooks/AdjustWindowRectHook.cpp
@@ -32,12 +32,12 @@ namespace Proto
 	void AdjustWindowRectHook::ShowGuiStatus()
 	{
 		int pos[2] = { posx, posy };
-		ImGui::SliderInt2("Position", &pos[0], -5000, 5000);
+		ImGui::InputInt2("Position", &pos[0]);
 		posx = pos[0];
 		posy = pos[1];
 
 		int size[2] = { width, height };
-		ImGui::SliderInt2("Size", &size[0], 0, 5000);
+		ImGui::InputInt2("Size", &size[0]);
 		width = size[0];
 		height = size[1];
 	}

--- a/src/ProtoInput/ProtoInputHooks/FakeCursor.cpp
+++ b/src/ProtoInput/ProtoInputHooks/FakeCursor.cpp
@@ -9,11 +9,17 @@ namespace Proto
 {
 
 FakeCursor FakeCursor::state{};
+#define WM_MOVE_pointerWindow (WM_APP + 1)
 
 LRESULT WINAPI FakeCursorWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
     switch (msg)
     {
+    case WM_MOVE_pointerWindow:
+    {
+        FakeCursor::state.GetWindowDimensions(hWnd);
+        break;
+    }
     case WM_DESTROY:
         PostQuitMessage(0);
         return 0;
@@ -22,6 +28,29 @@ LRESULT WINAPI FakeCursorWndProc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPar
     }
 
     return DefWindowProc(hWnd, msg, wParam, lParam);
+}
+
+void FakeCursor::GetWindowDimensions(HWND pointerWindow)
+{
+    HWND tHwnd = (HWND)HwndSelector::GetSelectedHwnd();
+    if (pointerWindow == tHwnd)
+        return;
+
+    if (IsWindow(tHwnd))
+    {
+        RECT cRect;
+        GetClientRect(tHwnd, &cRect);
+
+        POINT topLeft = { cRect.left, cRect.top };
+        ClientToScreen(tHwnd, &topLeft);
+
+        SetWindowPos(pointerWindow, HWND_TOPMOST,
+            topLeft.x,
+            topLeft.y,
+            cRect.right - cRect.left,
+            cRect.bottom - cRect.top,
+            SWP_NOACTIVATE);
+    }
 }
 
 LONG fakeCursorMinX = 0, fakeCursorMaxX = 0, fakeCursorMinY = 0, fakeCursorMaxY = 0;
@@ -139,6 +168,31 @@ DWORD WINAPI FakeCursorDrawLoopThread(LPVOID lpParameter)
     return 0;
 }
 
+DWORD WINAPI PointerWindowLoopThread(LPVOID lpParameter)
+{
+    printf("Pointer window loop thread start\n");
+    Proto::AddThreadToACL(GetCurrentThreadId());
+    FakeCursor::state.UpdatePointerWindowLoopInternal();
+
+    return 0;
+}
+
+void FakeCursor::UpdatePointerWindowLoopInternal()
+{
+    while (true)
+    {
+        HWND tHwnd = (HWND)HwndSelector::GetSelectedHwnd();
+        if (!IsWindow(tHwnd))
+        {
+            Sleep(2000);
+            continue;
+        }
+        PostMessage(pointerWindow, WM_MOVE_pointerWindow, 0, 0);
+
+        Sleep(5000);
+    }
+}
+
 void FakeCursor::StartDrawLoopInternal()
 {
     int tick = 0;
@@ -153,11 +207,15 @@ void FakeCursor::StartDrawLoopInternal()
         //TODO: is this ok? (might eat cpu)
         Sleep(drawingEnabled ? 12 : 500);
 
-        tick = (tick + 1) % 200;
+        if (!FakeMouseKeyboard::PutMouseInsideWindow)
+        {
 
-        if (tick == 0)
-            // Nucleus can put the game window above the pointer without this
-            SetWindowPos(pointerWindow, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOREDRAW | SWP_NOSIZE);
+            tick = (tick + 1) % 200;
+
+            if (tick == 0)
+                // Nucleus can put the game window above the pointer without this
+                SetWindowPos(pointerWindow, HWND_TOPMOST, 0, 0, 0, 0, SWP_NOMOVE | SWP_NOREDRAW | SWP_NOSIZE);
+        }
 	}
 }
 
@@ -182,19 +240,33 @@ void FakeCursor::StartInternal()
     wc.lpszClassName = className;
     wc.style = CS_OWNDC | CS_NOCLOSE;
 
+    Sleep(1000);
+
     if (!RegisterClass(&wc))
     {
         fprintf(stderr, "Failed to open fake cursor window\n");
     }
     else
     {
-        pointerWindow = CreateWindowExW(WS_EX_NOACTIVATE | WS_EX_NOINHERITLAYOUT | WS_EX_NOPARENTNOTIFY |
-                                                          WS_EX_TOPMOST | WS_EX_TRANSPARENT | WS_EX_TOOLWINDOW | WS_EX_LAYERED,
-                                                          wc.lpszClassName, classNameStr.c_str(), 0,
-                                                          0, 0, 200, 200,
-                                                          nullptr, nullptr, hInstance, nullptr);
+        if (FakeMouseKeyboard::PutMouseInsideWindow)
+        {
+            pointerWindow = CreateWindowExW(WS_EX_NOACTIVATE | WS_EX_NOINHERITLAYOUT | WS_EX_NOPARENTNOTIFY |
+                WS_EX_TOPMOST | WS_EX_TRANSPARENT | WS_EX_TOOLWINDOW | WS_EX_LAYERED,
+                wc.lpszClassName, classNameStr.c_str(),
+                WS_POPUP | WS_VISIBLE,
+                0, 0, HwndSelector::windowWidth, HwndSelector::windowHeight,
+                nullptr, nullptr, hInstance, nullptr);
+        }
+        else
+        {
+            pointerWindow = CreateWindowExW(WS_EX_NOACTIVATE | WS_EX_NOINHERITLAYOUT | WS_EX_NOPARENTNOTIFY |
+                WS_EX_TOPMOST | WS_EX_TRANSPARENT | WS_EX_TOOLWINDOW | WS_EX_LAYERED,
+                wc.lpszClassName, classNameStr.c_str(), 0,
+                0, 0, 200, 200,
+                nullptr, nullptr, hInstance, nullptr);
 
-        SetWindowLongW(pointerWindow, GWL_STYLE, WS_VISIBLE | WS_DISABLED);
+            SetWindowLongW(pointerWindow, GWL_STYLE, WS_VISIBLE | WS_DISABLED);
+        }
         SetLayeredWindowAttributes(pointerWindow, transparencyKey, 0, LWA_COLORKEY);
 
         // Nucleus can put the game window above the pointer without this
@@ -204,9 +276,12 @@ void FakeCursor::StartInternal()
         // UpdateWindow(pointerWindow);
         EnableDisableFakeCursor(drawingEnabled);
 
-    	// Over every screen
-        EnumDisplayMonitors(nullptr, nullptr, &EnumWindowsProc, 0);
-        MoveWindow(pointerWindow, fakeCursorMinX, fakeCursorMinY, fakeCursorMaxX - fakeCursorMinX, fakeCursorMaxY - fakeCursorMinY, TRUE);
+        if (!FakeMouseKeyboard::PutMouseInsideWindow)
+        {
+            // Over every screen
+            EnumDisplayMonitors(nullptr, nullptr, &EnumWindowsProc, 0);
+            MoveWindow(pointerWindow, fakeCursorMinX, fakeCursorMinY, fakeCursorMaxX - fakeCursorMinX, fakeCursorMaxY - fakeCursorMinY, TRUE);
+        }
 
         hdc = GetDC(pointerWindow);
 
@@ -218,6 +293,15 @@ void FakeCursor::StartInternal()
 
         if (threadHandle != nullptr)
             CloseHandle(threadHandle);
+
+        if (FakeMouseKeyboard::PutMouseInsideWindow)
+        {
+            const auto pointerThreadHandle = CreateThread(nullptr, 0,
+                (LPTHREAD_START_ROUTINE)PointerWindowLoopThread, GetModuleHandle(0), 0, 0);
+
+            if (pointerThreadHandle != nullptr)
+                CloseHandle(pointerThreadHandle);
+        }
 
     	// Want to avoid doing anything in the message loop that might cause it to not respond, as the entire screen will say not responding...
         MSG msg;

--- a/src/ProtoInput/ProtoInputHooks/FakeCursor.h
+++ b/src/ProtoInput/ProtoInputHooks/FakeCursor.h
@@ -43,6 +43,8 @@ public:
 	bool DrawFakeCursorFix;
 	void StartInternal();
 	void StartDrawLoopInternal();
+	void UpdatePointerWindowLoopInternal(); // Checks the selected window dimensions.
+	void GetWindowDimensions(HWND hWnd); // For pointerWindow
 
 	static bool& GetToggleVisilbityShorcutEnabled()
 	{

--- a/src/ProtoInput/ProtoInputHooks/FakeMouseKeyboard.cpp
+++ b/src/ProtoInput/ProtoInputHooks/FakeMouseKeyboard.cpp
@@ -213,6 +213,29 @@ void FakeMouseKeyboard::ClearAsyncKeyState(int vkey)
 	}
 }
 
+bool FakeMouseKeyboard::IsExtendedKey(int vkey)
+{
+	switch (vkey)
+	{
+	case VK_UP:
+	case VK_DOWN:
+	case VK_LEFT:
+	case VK_RIGHT:
+	case VK_HOME:
+	case VK_END:
+	case VK_PRIOR:
+	case VK_NEXT:
+	case VK_INSERT:
+	case VK_DELETE:
+	case VK_RCONTROL:
+	case VK_RMENU:
+	case VK_SEPARATOR:
+		return true;
+	default:
+		return false;
+	}
+}
+
 bool FakeMouseKeyboard::IsKeyStatePressed(int vkey)
 {
 	if (vkey >= 0 && vkey < keyboardState.keysState.size())

--- a/src/ProtoInput/ProtoInputHooks/FakeMouseKeyboard.cpp
+++ b/src/ProtoInput/ProtoInputHooks/FakeMouseKeyboard.cpp
@@ -59,10 +59,10 @@ void FakeMouseKeyboard::AddMouseDelta(int dx, int dy)
 		{
 			if (!DefaultBottomRightMouseBounds)
 			{
-				if (int max = mouseState.extendMouseBounds ? HwndSelector::windowWidth * 2 : HwndSelector::windowWidth; mouseState.x > max)
+				if (int max = mouseState.extendMouseBounds ? HwndSelector::windowWidth * 2 : HwndSelector::windowWidth; mouseState.x >= max)
 					mouseState.x = max - 1;
 
-				if (int max = mouseState.extendMouseBounds ? HwndSelector::windowHeight * 2 : HwndSelector::windowHeight; mouseState.y > max)
+				if (int max = mouseState.extendMouseBounds ? HwndSelector::windowHeight * 2 : HwndSelector::windowHeight; mouseState.y >= max)
 					mouseState.y = max - 1;
 			}
 			else if (DefaultBottomRightMouseBounds)
@@ -137,9 +137,9 @@ void FakeMouseKeyboard::SetMousePos(int x, int y)
 		{
 			if (!DefaultBottomRightMouseBounds)
 			{
-				if (int max = mouseState.extendMouseBounds ? HwndSelector::windowWidth * 2 : HwndSelector::windowWidth; mouseState.x > max)
+				if (int max = mouseState.extendMouseBounds ? HwndSelector::windowWidth * 2 : HwndSelector::windowWidth; mouseState.x >= max)
 					mouseState.x = max - 1;
-				if (int max = mouseState.extendMouseBounds ? HwndSelector::windowHeight * 2 : HwndSelector::windowHeight; mouseState.y > max)
+				if (int max = mouseState.extendMouseBounds ? HwndSelector::windowHeight * 2 : HwndSelector::windowHeight; mouseState.y >= max)
 					mouseState.y = max - 1;
 			}
 			else if (DefaultBottomRightMouseBounds)

--- a/src/ProtoInput/ProtoInputHooks/FakeMouseKeyboard.h
+++ b/src/ProtoInput/ProtoInputHooks/FakeMouseKeyboard.h
@@ -55,6 +55,8 @@ public:
 	static void ClearAsyncKeyState(int vkey);
 	static bool IsKeyStatePressed(int vkey);
 	static bool IsAsyncKeyStatePressed(int vkey);
+	//To use the exteended key flag (like arrow keys)
+	static bool IsExtendedKey(int vkey);
 
 	// Some games must use the exact window rect to determine the edge of the window.
 	static bool PutMouseInsideWindow;

--- a/src/ProtoInput/ProtoInputHooks/Gui.h
+++ b/src/ProtoInput/ProtoInputHooks/Gui.h
@@ -8,6 +8,7 @@ namespace Proto
 extern unsigned long GuiThreadID;
 extern intptr_t ConsoleHwnd;
 extern HWND ProtoGuiHwnd;
+extern bool DisableGuiWindow;
 
 int ShowGuiImpl();
 

--- a/src/ProtoInput/ProtoInputHooks/GuiImpl.cpp
+++ b/src/ProtoInput/ProtoInputHooks/GuiImpl.cpp
@@ -15,6 +15,7 @@
 //TODO: default to hidden
 constexpr bool defaultGuiToHidden = true;
 constexpr bool defaultConsoleToHidden = true;
+bool Proto::DisableGuiWindow = false;
 
 HGLRC   g_GLRenderContext;
 HDC     g_HDCDeviceContext;
@@ -139,6 +140,9 @@ void Proto::SetConsoleVisible(bool visible)
 
 int Proto::ShowGuiImpl()
 {
+    if (Proto::DisableGuiWindow)
+        return 0;
+
     auto hInstance = GetModuleHandle(NULL);
 
     WNDCLASS wc = { 0 };

--- a/src/ProtoInput/ProtoInputHooks/MoveWindowHook.cpp
+++ b/src/ProtoInput/ProtoInputHooks/MoveWindowHook.cpp
@@ -1,5 +1,6 @@
 #include "MoveWindowHook.h"
 #include <imgui.h>
+#include "HwndSelector.h"
 
 namespace Proto
 {
@@ -25,14 +26,24 @@ namespace Proto
 	void MoveWindowHook::ShowGuiStatus()
 	{
 		int pos[2] = { posx, posy };
-		ImGui::SliderInt2("Position", &pos[0], -5000, 5000);
+		ImGui::InputInt2("Position", &pos[0]);
 		posx = pos[0];
 		posy = pos[1];
 
 		int size[2] = { width, height };
-		ImGui::SliderInt2("Size", &size[0], 0, 5000);
+		ImGui::InputInt2("Size", &size[0]);
 		width = size[0];
 		height = size[1];
+
+		ImGui::Separator();
+
+		if (ImGui::Button("Apply Changes"))
+		{
+			if ((HWND)HwndSelector::GetSelectedHwnd() != NULL)
+			{
+				::MoveWindow((HWND)HwndSelector::GetSelectedHwnd(), posx, posy, width, height, TRUE);
+			}
+		}
 	}
 
 	void MoveWindowHook::InstallImpl()

--- a/src/ProtoInput/ProtoInputHooks/MoveWindowHook.h
+++ b/src/ProtoInput/ProtoInputHooks/MoveWindowHook.h
@@ -25,7 +25,7 @@ namespace Proto
 			return
 				"When the game tries to reposition/resize its game window, this hook forces it to a fixed position and size. ";
 		}
-		bool HasGuiStatus() const override { return false; }
+		bool HasGuiStatus() const override { return true; }
 		void ShowGuiStatus() override;
 		void InstallImpl() override;
 		void UninstallImpl() override;

--- a/src/ProtoInput/ProtoInputHooks/PipeCommunication.cpp
+++ b/src/ProtoInput/ProtoInputHooks/PipeCommunication.cpp
@@ -3,6 +3,7 @@
 #include "PipeCommunication.h"
 #include <iostream>
 #include "HookManager.h"
+#include "Gui.h"
 
 #include "pipeinclude/pipeinclude.h"
 #include <imgui.h>
@@ -573,6 +574,16 @@ DWORD WINAPI PipeThread(LPVOID lpParameter)
 				printf("Received DontWaitWindowBorder, enabled = %d\n", body->DontWaitWindowBorder);
 
 				RemoveBorderHook::DontWaitWindowBorder = body->DontWaitWindowBorder;
+
+				break;
+			}
+			case ProtoPipe::PipeMessageType::DisableGuiWindow:
+			{
+				const auto body = reinterpret_cast<ProtoPipe::PipeMessageDisableGuiWindow*>(messageBuffer);
+
+				printf("Received DisableGuiWindow, enabled = %d\n", body->DisableGuiWindow);
+
+				Proto::DisableGuiWindow = body->DisableGuiWindow;
 
 				break;
 			}

--- a/src/ProtoInput/ProtoInputHooks/RawInput.cpp
+++ b/src/ProtoInput/ProtoInputHooks/RawInput.cpp
@@ -185,14 +185,14 @@ void RawInput::ProcessMouseInput(const RAWMOUSE& data, HANDLE deviceHandle)
 			PostMessageW((HWND)HwndSelector::GetSelectedHwnd(), WM_RBUTTONUP, mouseMkFlags | MouseButtonFilter::signature, mousePointLparam);
 
 		if ((data.usButtonFlags & RI_MOUSE_BUTTON_4_DOWN) != 0)
-			PostMessageW((HWND)HwndSelector::GetSelectedHwnd(), WM_XBUTTONDOWN, mouseMkFlags | (XBUTTON1 << 4) | MouseButtonFilter::signature, mousePointLparam);
+			PostMessageW((HWND)HwndSelector::GetSelectedHwnd(), WM_XBUTTONDOWN, (mouseMkFlags | MK_XBUTTON1) | (XBUTTON1 << 16) | MouseButtonFilter::signature, mousePointLparam);
 		if ((data.usButtonFlags & RI_MOUSE_BUTTON_4_UP) != 0)
-			PostMessageW((HWND)HwndSelector::GetSelectedHwnd(), WM_XBUTTONUP, mouseMkFlags | (XBUTTON1 << 4) | MouseButtonFilter::signature, mousePointLparam);
+			PostMessageW((HWND)HwndSelector::GetSelectedHwnd(), WM_XBUTTONUP, (mouseMkFlags | MK_XBUTTON1) | (XBUTTON1 << 16) | MouseButtonFilter::signature, mousePointLparam);
 
 		if ((data.usButtonFlags & RI_MOUSE_BUTTON_5_DOWN) != 0)
-			PostMessageW((HWND)HwndSelector::GetSelectedHwnd(), WM_XBUTTONDOWN, mouseMkFlags | (XBUTTON2 << 4) | MouseButtonFilter::signature, mousePointLparam);
+			PostMessageW((HWND)HwndSelector::GetSelectedHwnd(), WM_XBUTTONDOWN, (mouseMkFlags | MK_XBUTTON2) | (XBUTTON2 << 16) | MouseButtonFilter::signature, mousePointLparam);
 		if ((data.usButtonFlags & RI_MOUSE_BUTTON_5_UP) != 0)
-			PostMessageW((HWND)HwndSelector::GetSelectedHwnd(), WM_XBUTTONUP, mouseMkFlags | (XBUTTON2 << 4) | MouseButtonFilter::signature, mousePointLparam);
+			PostMessageW((HWND)HwndSelector::GetSelectedHwnd(), WM_XBUTTONUP, (mouseMkFlags | MK_XBUTTON2) | (XBUTTON2 << 16) | MouseButtonFilter::signature, mousePointLparam);
 	}
 
 
@@ -233,6 +233,11 @@ void RawInput::ProcessKeyboardInput(const RAWKEYBOARD& data, HANDLE deviceHandle
 			{
 				lparam |= (1 << 30);
 			}
+
+			if (FakeMouseKeyboard::IsExtendedKey(data.VKey))
+			{
+				lparam |= (1 << 24); // Set the extended-key flag
+			}
 			
 			PostMessageW((HWND)HwndSelector::GetSelectedHwnd(), WM_KEYDOWN, 
 				MessageFilterHook::IsKeyboardButtonFilterEnabled() ? data.VKey | KeyboardButtonFilter::signature : data.VKey, 
@@ -255,6 +260,11 @@ void RawInput::ProcessKeyboardInput(const RAWKEYBOARD& data, HANDLE deviceHandle
 			lparam |= (data.MakeCode << 16); // Scan code
 			lparam |= (1 << 30); // Previous key state (always 1 for key up)
 			lparam |= (1 << 31); // Transition state (always 1 for key up)
+
+			if (FakeMouseKeyboard::IsExtendedKey(data.VKey))
+			{
+				lparam |= (1 << 24); // Set the extended-key flag
+			}
 
 			PostMessageW((HWND)HwndSelector::GetSelectedHwnd(), WM_KEYUP, 
 				MessageFilterHook::IsKeyboardButtonFilterEnabled() ? data.VKey | KeyboardButtonFilter::signature : data.VKey,

--- a/src/ProtoInput/ProtoInputHooks/SetWindowPosHook.cpp
+++ b/src/ProtoInput/ProtoInputHooks/SetWindowPosHook.cpp
@@ -1,5 +1,6 @@
 #include "SetWindowPosHook.h"
 #include <imgui.h>
+#include "HwndSelector.h"
 
 namespace Proto
 {
@@ -25,14 +26,24 @@ BOOL WINAPI Hook_SetWindowPos(HWND hWnd, HWND hWndInsertAfter, int X, int Y, int
 void SetWindowPosHook::ShowGuiStatus()
 {
 	int pos[2] = { posx, posy };
-	ImGui::SliderInt2("Position", &pos[0], -5000, 5000);
+	ImGui::InputInt2("Position", &pos[0]);
 	posx = pos[0];
 	posy = pos[1];
 	
 	int size[2] = { width, height };
-	ImGui::SliderInt2("Size", &size[0], 0, 5000);
+	ImGui::InputInt2("Size", &size[0]);
 	width = size[0];
 	height = size[1];
+
+	ImGui::Separator();
+
+	if (ImGui::Button("Apply Changes"))
+	{
+		if ((HWND)HwndSelector::GetSelectedHwnd() != NULL)
+		{
+			::SetWindowPos((HWND)HwndSelector::GetSelectedHwnd(), NULL, posx, posy, width, height, SWP_NOZORDER | SWP_NOACTIVATE);
+		}
+	}
 }
 
 void SetWindowPosHook::InstallImpl()

--- a/src/ProtoInput/ProtoInputHooks/dllmain.cpp
+++ b/src/ProtoInput/ProtoInputHooks/dllmain.cpp
@@ -25,6 +25,16 @@ DWORD WINAPI GuiThread(LPVOID lpParameter)
 
 	Proto::AddThreadToACL(GetCurrentThreadId());
 
+    //TODO: Find a better way to wait for `DisableGuiWindow`?
+    for (int i = 0; i < 10; ++i)
+    {
+        if (Proto::DisableGuiWindow)
+        {
+            break;
+        }
+        Sleep(100);
+    }
+
     Proto::ShowGuiImpl();
 
     return 0;
@@ -52,13 +62,13 @@ DWORD WINAPI StartThread(LPVOID lpParameter)
     Proto::FakeCursor::Initialise();
 	
     Proto::AddThreadToACL(GetCurrentThreadId());
+
+    Proto::StartPipeCommunication();
 	
     HANDLE hGuiThread = CreateThread(nullptr, 0,
                                   (LPTHREAD_START_ROUTINE)GuiThread, dll_hModule, CREATE_SUSPENDED, &Proto::GuiThreadID);
   
     Proto::RawInput::InitialiseRawInput();
-    	
-    Proto::StartPipeCommunication();
 
     ResumeThread(hGuiThread);
 

--- a/src/ProtoInput/ProtoInputHooks/pipeinclude/pipeinclude.h
+++ b/src/ProtoInput/ProtoInputHooks/pipeinclude/pipeinclude.h
@@ -42,7 +42,8 @@ enum class PipeMessageType
 	SetMoveWindowDontResize,
 	SetMoveWindowDontReposition,
 	SetAdjustWindowRectSettings,
-	SetDontWaitWindowBorder
+	SetDontWaitWindowBorder,
+	DisableGuiWindow
 };
 
 struct PipeMessageHeader
@@ -254,6 +255,11 @@ struct PipeMessageSetAdjustWindowRectSettings
 struct PipeMessageSetDontWaitWindowBorder
 {
 	bool DontWaitWindowBorder;
+};
+
+struct PipeMessageDisableGuiWindow
+{
+	bool DisableGuiWindow;
 };
 
 }

--- a/src/ProtoInput/ProtoInputLoader/Inject.cpp
+++ b/src/ProtoInput/ProtoInputLoader/Inject.cpp
@@ -679,3 +679,20 @@ void SetDontWaitWindowBorder(ProtoInstanceHandle instanceHandle, bool enabled)
 		ProtoSendPipeMessage(instance.pipeHandle, ProtoPipe::PipeMessageType::SetDontWaitWindowBorder, &message);
 	}
 }
+
+void DisableGuiWindow(ProtoInstanceHandle instanceHandle, bool enabled)
+{
+	if (const auto find = Proto::instances.find(instanceHandle); find != Proto::instances.end())
+	{
+		auto& instance = find->second;
+
+		WaitClientConnect(instance);
+
+		ProtoPipe::PipeMessageDisableGuiWindow message
+		{
+			enabled
+		};
+
+		ProtoSendPipeMessage(instance.pipeHandle, ProtoPipe::PipeMessageType::DisableGuiWindow, &message);
+	}
+}

--- a/src/ProtoInput/ProtoInputLoader/include/protoloader.h
+++ b/src/ProtoInput/ProtoInputLoader/include/protoloader.h
@@ -116,9 +116,7 @@ extern "C" __declspec(dllexport) void SetDinputDeviceGUID(ProtoInstanceHandle in
 extern "C" __declspec(dllexport) void DinputHookAlsoHooksGetDeviceState(ProtoInstanceHandle instanceHandle, bool enable);
 
 extern "C" __declspec(dllexport) void SetSetWindowPosSettings(ProtoInstanceHandle instanceHandle, int posx, int posy, int width, int height);
-
 extern "C" __declspec(dllexport) void SetSetWindowPosDontResize(ProtoInstanceHandle instanceHandle, bool enabled);
-
 extern "C" __declspec(dllexport) void SetSetWindowPosDontReposition(ProtoInstanceHandle instanceHandle, bool enabled);
 
 extern "C" __declspec(dllexport) void SetCreateSingleHIDName(ProtoInstanceHandle instanceHandle, const wchar_t* name);
@@ -134,17 +132,15 @@ extern "C" __declspec(dllexport) void SetRawInputBypass(ProtoInstanceHandle inst
 extern "C" __declspec(dllexport) void SetShowCursorWhenImageUpdated(ProtoInstanceHandle instanceHandle, bool enabled);
 
 extern "C" __declspec(dllexport) void SetPutMouseInsideWindow(ProtoInstanceHandle instanceHandle, bool enabled);
-
 extern "C" __declspec(dllexport) void SetDefaultTopLeftMouseBounds(ProtoInstanceHandle instanceHandle, bool enabled);
-
 extern "C" __declspec(dllexport) void SetDefaultBottomRightMouseBounds(ProtoInstanceHandle instanceHandle, bool enabled);
 
 extern "C" __declspec(dllexport) void SetMoveWindowSettings(ProtoInstanceHandle instanceHandle, int posx, int posy, int width, int height);
-
 extern "C" __declspec(dllexport) void SetMoveWindowDontResize(ProtoInstanceHandle instanceHandle, bool enabled);
-
 extern "C" __declspec(dllexport) void SetMoveWindowDontReposition(ProtoInstanceHandle instanceHandle, bool enabled);
 
 extern "C" __declspec(dllexport) void SetAdjustWindowRectSettings(ProtoInstanceHandle instanceHandle, int posx, int posy, int width, int height);
 
 extern "C" __declspec(dllexport) void SetDontWaitWindowBorder(ProtoInstanceHandle instanceHandle, bool enabled);
+
+extern "C" __declspec(dllexport) void DisableGuiWindow(ProtoInstanceHandle instanceHandle, bool enabled);


### PR DESCRIPTION
Added `DisableGuiWindow` workaround option to avoid the crash with incompatible games.
Added  `extended key flag` for Keyboard buttons.
Fixed the `X1`, `X2` of mouse buttons.
Enhanced the `PutMouseInsideWindow` for more realistic cursor behavior within the window.
Enhanced the GUI use for `SetWindowPos`, `MoveWindow` and `AdjustWindowRect`.