### PR TITLE
Update PipeCommunication.cpp

### DIFF
--- a/src/ProtoInput/ProtoInputHooks/PipeCommunication.cpp
+++ b/src/ProtoInput/ProtoInputHooks/PipeCommunication.cpp
@@ -350,7 +350,7 @@ DWORD WINAPI PipeThread(LPVOID lpParameter)
 				const auto body = reinterpret_cast<ProtoPipe::PipeMessageSetDrawFakeCursorFix*>(messageBuffer);
 
 				printf("Received message to %s fake cursor with offset fix\n", body->enable ? "enable" : "disable");
-				FakeCursor::EnableDisableFakeCursor(body->enable);
+
 				FakeCursor::DrawFakeCursorFix = body->enable;
 				break;
 			}


### PR DESCRIPTION
Was a problem. EnableDisableFakeCursor was called twice. true on first call if DrawFakeCursor, and false right after if DrawFakeCursorFix was false. fixed now. And both lines needs to be true to draw cursor with DrawFakeCursorFix